### PR TITLE
docs: define project master plan (#11)

### DIFF
--- a/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `docs/11--define-project-master-plan`
 - Goal: write `docs/MASTER-PLAN.md` as the top-level delivery plan for the current Mandalart Web baseline.
-- Status: `Spec`, `Research`, and `Planner` are complete. `Execution` is in progress and Slice 1 is approved for commit.
+- Status: `Spec`, `Research`, and `Planner` are complete. `Execution` is in progress and Slice 3 is approved for commit.
 
 ## Completed
 
@@ -32,12 +32,23 @@
    - replaced placeholder prose with concise product and UX direction
    - added concise architecture and branch-delivery principles
    - kept the non-roadmap sections intentionally thin so the roadmap remains the main output
+7. Executed Slice 3 in `docs/MASTER-PLAN.md`:
+   - added the sequencing logic for the roadmap
+   - replaced the one-branch-per-phase reading with a phase model that can contain multiple smaller branches
+   - reduced Phase 2 to one focused design-foundation branch
+   - merged landing and dashboard into one surface-refresh phase with two branches
+   - renamed later phase titles and branch slugs to keep branch intent easier to scan
+   - expanded the roadmap to cover profile page, boards list page, board create/list/detail shell, and the MVP board-view/editing model
+   - kept the roadmap at planning level instead of expanding it into branch-local specs
 
 ## Decisions
 
 - `docs/MASTER-PLAN.md` should be a hybrid delivery master plan, not a duplicate PRD and not a pure architecture charter.
 - The document must sit above `docs/PRD.md`, `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`, and explain how they connect.
 - The branch roadmap is the primary output of the document; surrounding sections should stay concise and only support roadmap readability.
+- Roadmap phases are milestone groupings, not mandatory one-branch units.
+- The current roadmap treats landing-first as the preferred refresh order; dashboard can follow once the design foundation is stable.
+- Branch slugs should stay as single-purpose as possible even when phase titles stay broader.
 - The document must explicitly preserve:
   - service name
   - color direction
@@ -48,9 +59,8 @@
 
 ## Pending
 
-1. Commit Slice 2 after the current execution step is recorded.
+1. Commit the approved Slice 3 roadmap changes.
 2. Continue with:
-   - Slice 3: branch roadmap and sequencing as the main deliverable
    - Slice 4: finalization, Korean sync, and minimal cross-reference touch-ups
 
 ## Risks / Notes
@@ -65,7 +75,12 @@
   - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/spec.md' '.agent/sessions/[#11]docs--define-project-master-plan/research.md' '.agent/sessions/[#11]docs--define-project-master-plan/plan.md' '.agent/sessions/[#11]docs--define-project-master-plan/plans/01-branch-baseline.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
   - `rg -n "Current Baseline|Fixed Constraints|Source-of-Truth Map|Branch Roadmap" docs/MASTER-PLAN.md` -> pass
   - `git diff --check -- 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan'` -> pass
+- Slice 3 verification completed:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md'` -> pass
+  - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md` -> pass
+  - `git diff --check -- 'docs/MASTER-PLAN.md'` -> pass
+  - `rg -n "Phase Model|Phase 2 - Design Foundation Refresh|Phase 3 - Surface Refresh|Phase 4 - Account Foundation|Phase 5 - Board Foundation|Phase 6 - Board Editing|read-only|app-shell-route-guard|board-domain-foundation|boards-page|cell-detail-flow|board-save-flow" docs/MASTER-PLAN.md` -> pass
 
 ## Resume
 
-- Next prompt: "Review the Slice 1 draft in `docs/MASTER-PLAN.md` and either approve the planned commit or request changes before Slice 2 starts."
+- Next prompt: "Review the roadmap in `docs/MASTER-PLAN.md` and either approve the Slice 3 commit or request changes before finalization starts."

--- a/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
@@ -1,0 +1,68 @@
+# Handoff
+
+## Context
+
+- Branch: `docs/11--define-project-master-plan`
+- Goal: write `docs/MASTER-PLAN.md` as the top-level delivery plan for the current Mandalart Web baseline.
+- Status: `Spec`, `Research`, and `Planner` are complete. `Execution` is in progress and Slice 1 is approved for commit.
+
+## Completed
+
+1. Resolved the new session root at `.agent/sessions/[#11]docs--define-project-master-plan/`.
+2. Read the previous handoff from `[#9]docs--update-agentic-docs` and used it as a required input.
+3. Confirmed the current baseline from local evidence:
+   - project setup is already in place
+   - token and color foundation exists in `src/app/globals.css`
+   - landing UI exists
+   - dashboard UI exists
+   - the visual language already uses warm paper/card/tape and memo-like cues
+4. Wrote branch-local planning artifacts:
+   - `spec.md`
+   - `research.md`
+   - `plan.md`
+   - `plans/01-branch-baseline.md`
+   - `log.md`
+5. Executed Slice 1 draft work in `docs/MASTER-PLAN.md`:
+   - set the document purpose
+   - positioned it relative to the other source-of-truth docs
+   - documented the current repository baseline
+   - fixed the project-level identity, visual-system, architecture, and workflow constraints
+   - added the high-level section skeleton for the remaining slices
+
+## Decisions
+
+- `docs/MASTER-PLAN.md` should be a hybrid delivery master plan, not a duplicate PRD and not a pure architecture charter.
+- The document must sit above `docs/PRD.md`, `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`, and explain how they connect.
+- The branch roadmap is the primary output of the document; surrounding sections should stay concise and only support roadmap readability.
+- The document must explicitly preserve:
+  - service name
+  - color direction
+  - semantic token contract
+  - memo/paper/note-taking concept
+- The roadmap should be written from the current repository baseline, not from a greenfield assumption.
+- UI refresh should be planned as dedicated follow-up UI branches, not mixed into deeper feature branches.
+
+## Pending
+
+1. Commit the approved Slice 1 draft.
+2. Continue with:
+   - Slice 2: minimal planning principles only
+   - Slice 3: branch roadmap and sequencing as the main deliverable
+   - Slice 4: finalization, Korean sync, and minimal cross-reference touch-ups
+
+## Risks / Notes
+
+- Keep `docs/MASTER-PLAN.md` at planning level. If it starts absorbing detailed PRD or technical-spec content, trim it back.
+- Treat the current landing/dashboard UI as the active baseline even if follow-up UI branches will redesign parts of it.
+- Leave unrelated worktree changes in `.github/workflows/playwright.yml` and `pnpm-lock.yaml` untouched unless the user asks otherwise.
+
+## Verification
+
+- Slice 1 verification completed:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/spec.md' '.agent/sessions/[#11]docs--define-project-master-plan/research.md' '.agent/sessions/[#11]docs--define-project-master-plan/plan.md' '.agent/sessions/[#11]docs--define-project-master-plan/plans/01-branch-baseline.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
+  - `rg -n "Current Baseline|Fixed Constraints|Source-of-Truth Map|Branch Roadmap" docs/MASTER-PLAN.md` -> pass
+  - `git diff --check -- 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan'` -> pass
+
+## Resume
+
+- Next prompt: "Review the Slice 1 draft in `docs/MASTER-PLAN.md` and either approve the planned commit or request changes before Slice 2 starts."

--- a/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
@@ -28,6 +28,10 @@
    - documented the current repository baseline
    - fixed the project-level identity, visual-system, architecture, and workflow constraints
    - added the high-level section skeleton for the remaining slices
+6. Executed Slice 2 in `docs/MASTER-PLAN.md`:
+   - replaced placeholder prose with concise product and UX direction
+   - added concise architecture and branch-delivery principles
+   - kept the non-roadmap sections intentionally thin so the roadmap remains the main output
 
 ## Decisions
 
@@ -44,9 +48,8 @@
 
 ## Pending
 
-1. Commit the approved Slice 1 draft.
+1. Commit Slice 2 after the current execution step is recorded.
 2. Continue with:
-   - Slice 2: minimal planning principles only
    - Slice 3: branch roadmap and sequencing as the main deliverable
    - Slice 4: finalization, Korean sync, and minimal cross-reference touch-ups
 

--- a/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `docs/11--define-project-master-plan`
 - Goal: write `docs/MASTER-PLAN.md` as the top-level delivery plan for the current Mandalart Web baseline.
-- Status: `Spec`, `Research`, and `Planner` are complete. `Execution` is in progress and Slice 3 is approved for commit.
+- Status: branch work is complete. The English and Korean master-plan docs are in place, and final verification has been recorded.
 
 ## Completed
 
@@ -40,6 +40,11 @@
    - renamed later phase titles and branch slugs to keep branch intent easier to scan
    - expanded the roadmap to cover profile page, boards list page, board create/list/detail shell, and the MVP board-view/editing model
    - kept the roadmap at planning level instead of expanding it into branch-local specs
+8. Executed Slice 4 and closeout work:
+   - finalized sections 9 and 10 of `docs/MASTER-PLAN.md`
+   - updated the English master-plan timestamp
+   - added `docs/ko/MASTER-PLAN.md`
+   - recorded hardening, review, and final verification results in `log.md`
 
 ## Decisions
 
@@ -59,9 +64,8 @@
 
 ## Pending
 
-1. Commit the approved Slice 3 roadmap changes.
-2. Continue with:
-   - Slice 4: finalization, Korean sync, and minimal cross-reference touch-ups
+1. Optional follow-up only:
+   - open a PR or start the next roadmap branch
 
 ## Risks / Notes
 
@@ -80,7 +84,13 @@
   - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md` -> pass
   - `git diff --check -- 'docs/MASTER-PLAN.md'` -> pass
   - `rg -n "Phase Model|Phase 2 - Design Foundation Refresh|Phase 3 - Surface Refresh|Phase 4 - Account Foundation|Phase 5 - Board Foundation|Phase 6 - Board Editing|read-only|app-shell-route-guard|board-domain-foundation|boards-page|cell-detail-flow|board-save-flow" docs/MASTER-PLAN.md` -> pass
+- Slice 4 and final verification completed:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
+  - `git diff --check -- 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko` -> pass
+  - `rg -n "This section will" 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md'` -> pass
+  - `pnpm run lint` -> fail due existing repository-wide Biome configuration and formatting issues in unaffected files
 
 ## Resume
 
-- Next prompt: "Review the roadmap in `docs/MASTER-PLAN.md` and either approve the Slice 3 commit or request changes before finalization starts."
+- Next prompt: "Start the next roadmap branch from `docs/MASTER-PLAN.md`."

--- a/.agent/sessions/[#11]docs--define-project-master-plan/log.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/log.md
@@ -90,3 +90,68 @@
 - Slice checkpoint:
   - required
   - approval state: approved by user on 2026-03-17 before commit
+
+## 2026-03-17 - Slice 4 execution
+
+- Slice: `Slice 4`
+- Binding skill lens: `frontend-architecture-rules`
+- Key enforced constraints:
+  - finalize the English source without expanding branch scope
+  - sync the Korean translation only after the English source was accepted
+  - keep supporting document touch-ups minimal and limited to the master-plan surfaces
+- TDD cycle:
+  - RED: the English source still had unfinished closing sections, the Korean translation did not exist, and the branch was not yet ready for final doc verification.
+  - GREEN: finalized sections 9 and 10 in `docs/MASTER-PLAN.md`, updated the document timestamp, and added `docs/ko/MASTER-PLAN.md`.
+  - REFACTOR: kept the closing sections concise, aligned the Korean structure with the English source, and preserved the roadmap as the document's main output.
+- Verify:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
+  - `git diff --check -- 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko` -> pass
+  - `rg -n "This section will" 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md'` -> pass, no unresolved placeholder section markers
+  - `rg -n "cell-detail-task-editing|app-shell-and-route-guard|board-domain-and-create-flow|boards-list-and-navigation|Auth, App Shell, and Profile|Board Domain Foundation and Boards Index|Board View and Editor Flow" 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md'` -> pass, stale roadmap naming not found
+  - `test -f 'docs/ko/MASTER-PLAN.md' && echo '__KO_MASTER_PLAN_PRESENT__'` -> pass
+- Task checklist:
+  - complete
+
+## Hardening (branch)
+
+- Failure path tested:
+  - searched for unresolved placeholder section markers in the English and Korean master-plan docs
+  - searched for stale pre-replan phase and branch names after the roadmap rename pass
+- Observability signals checked:
+  - roadmap markers and translation-presence checks provide explicit doc-completion signals
+  - session artifacts remain present under the expected branch root
+- UX resilience checked:
+  - for this docs branch, the practical equivalent is readability and recoverability: the roadmap, verification rules, and replan triggers are explicit enough that the next thread can resume without guessing
+- Verify commands:
+  - `rg -n "This section will" 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md'`
+  - `rg -n "cell-detail-task-editing|app-shell-and-route-guard|board-domain-and-create-flow|boards-list-and-navigation|Auth, App Shell, and Profile|Board Domain Foundation and Boards Index|Board View and Editor Flow" 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md'`
+  - `test -f 'docs/ko/MASTER-PLAN.md' && echo '__KO_MASTER_PLAN_PRESENT__'`
+- Result summary:
+  - pass
+
+## Review
+
+- Findings:
+  - none
+- Open questions / assumptions:
+  - none blocking for this branch
+- Summary:
+  - the branch goal, scope, roadmap priority, and translation-sync requirements are reflected in the final master-plan docs without duplicating detailed ownership from `PRD`, `SCAFFOLD_STRUCTURE`, or `TECH_REFERENCE`
+
+## Refactor Pass
+
+- Findings addressed:
+  - finalized the closing sections of the English source
+  - synchronized the Korean translation
+  - kept roadmap naming consistent after the last slug cleanup
+- Refactor changes:
+  - no additional refactor beyond wording and translation alignment
+- Final verify command(s):
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'`
+  - `git diff --check -- 'docs/MASTER-PLAN.md' 'docs/ko/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'`
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko`
+  - `pnpm run lint`
+- Final verify result:
+  - document-specific verification passed
+  - `pnpm run lint` failed because of existing repository-wide Biome configuration and formatting issues in unaffected files, including `biome.json`, `src/app/globals.css`, `src/shared/lib/utils.ts`, `tests/e2e/example.spec.ts`, `playwright.config.ts`, and `src/shared/ui/ComponentExample.tsx`

--- a/.agent/sessions/[#11]docs--define-project-master-plan/log.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/log.md
@@ -38,3 +38,22 @@
 - Updated `spec.md` acceptance criteria to make roadmap priority explicit.
 - Replanned `plan.md` and saved the new accepted snapshot to `plans/02-roadmap-priority.md`.
 - Kept Slice 1 intact, but tightened Slice 2 and increased emphasis on Slice 3 as the main branch output.
+
+## 2026-03-16 - Slice 2 execution
+
+- Slice: `Slice 2`
+- Binding skill lens: `frontend-architecture-rules`
+- Key enforced constraints:
+  - keep non-roadmap sections concise and only detailed enough to support the roadmap
+  - point detailed ownership back to `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and `AGENTS`
+  - keep workflow and architecture guidance aligned with the existing project rules
+- TDD cycle:
+  - RED: Slice 1 left the product, UX, architecture, and branch-delivery guidance as placeholders, so the roadmap would still be missing its minimum interpretive context.
+  - GREEN: replaced the placeholders with concise `Product Direction`, `UX Direction`, `Architecture Principles`, and `Branch Delivery` sections.
+  - REFACTOR: trimmed explanatory language so the new sections support the roadmap without re-stating detailed product or technical specification content.
+- Verify:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md'` -> pass, no formatting changes needed
+  - `rg -n "Product Direction|UX Direction|Architecture Principles|Branch Delivery" docs/MASTER-PLAN.md` -> pass, required section markers found
+  - `git diff --check -- 'docs/MASTER-PLAN.md'` -> pass
+- Task checklist:
+  - complete

--- a/.agent/sessions/[#11]docs--define-project-master-plan/log.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/log.md
@@ -1,0 +1,40 @@
+# Log
+
+## 2026-03-15 - Cycle setup
+
+- Resolved the session artifact root for `docs/11--define-project-master-plan` as `.agent/sessions/[#11]docs--define-project-master-plan/`.
+- Read the previous branch handoff from `[#9]docs--update-agentic-docs` before starting the new cycle.
+- Reviewed the current project source docs, branch-cycle skill rules, current token surface, landing/dashboard UI baseline, and git branch history.
+- Wrote `spec.md` to fix branch intent, scope, constraints, and acceptance criteria for `docs/MASTER-PLAN.md`.
+- Wrote `research.md` to decide the master-plan role, document structure, and roadmap sequencing approach.
+- Wrote the accepted branch plan into `plan.md` and archived the baseline snapshot in `plans/01-branch-baseline.md`.
+- Deferred execution of `docs/MASTER-PLAN.md` to the next slice after planning artifacts were accepted.
+
+## 2026-03-15 - Slice 1 execution
+
+- Slice: `Slice 1`
+- Binding skill lens: `frontend-architecture-rules`
+- Key enforced constraints:
+  - keep `docs/MASTER-PLAN.md` above detailed PRD and technical ownership
+  - record the current repository baseline instead of describing a greenfield project
+  - preserve service identity, color direction, token system, and memo/paper concept as fixed constraints
+- TDD cycle:
+  - RED: `docs/MASTER-PLAN.md` did not exist, so the accepted spec and research requirements for document role, baseline, and fixed constraints were all failing.
+  - GREEN: created `docs/MASTER-PLAN.md` with purpose, source-of-truth map, current baseline, fixed constraints, and the section skeleton for later master-plan content.
+  - REFACTOR: tightened section ownership so the new document summarizes project-level responsibilities instead of duplicating `PRD`, `SCAFFOLD_STRUCTURE`, or `TECH_REFERENCE`.
+- Verify:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan/spec.md' '.agent/sessions/[#11]docs--define-project-master-plan/research.md' '.agent/sessions/[#11]docs--define-project-master-plan/plan.md' '.agent/sessions/[#11]docs--define-project-master-plan/plans/01-branch-baseline.md' '.agent/sessions/[#11]docs--define-project-master-plan/log.md' '.agent/sessions/[#11]docs--define-project-master-plan/handoff.md'` -> pass, no formatting changes needed
+  - `rg -n "Current Baseline|Fixed Constraints|Source-of-Truth Map|Branch Roadmap" docs/MASTER-PLAN.md` -> pass, required sections found
+  - `git diff --check -- 'docs/MASTER-PLAN.md' '.agent/sessions/[#11]docs--define-project-master-plan'` -> pass
+- Task checklist:
+  - complete
+- Slice checkpoint:
+  - required
+  - approval state: approved by user on 2026-03-16 before commit
+
+## 2026-03-16 - Replan
+
+- User clarified that the branch roadmap is the main purpose of `docs/MASTER-PLAN.md` and that non-roadmap sections should stay minimal.
+- Updated `spec.md` acceptance criteria to make roadmap priority explicit.
+- Replanned `plan.md` and saved the new accepted snapshot to `plans/02-roadmap-priority.md`.
+- Kept Slice 1 intact, but tightened Slice 2 and increased emphasis on Slice 3 as the main branch output.

--- a/.agent/sessions/[#11]docs--define-project-master-plan/log.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/log.md
@@ -57,3 +57,36 @@
   - `git diff --check -- 'docs/MASTER-PLAN.md'` -> pass
 - Task checklist:
   - complete
+
+## 2026-03-16 - Slice 3 execution
+
+- Slice: `Slice 3`
+- Binding skill lens: `frontend-design`
+- Key enforced constraints:
+  - make the roadmap the primary output of `docs/MASTER-PLAN.md`
+  - place UI refresh work early enough to preserve and unify the visible service identity
+  - keep the roadmap at planning level with clear dependencies and verification gates
+- TDD cycle:
+  - RED: after Slice 2, the document still lacked the actual branch sequence, dependency logic, and verification expectations that justify the master plan's existence.
+  - GREEN: added the sequencing logic, roadmap phase table, and dependency rules covering completed baseline, current branch, UI refresh, app shell, board domain, board editor, dashboard data, export/templates, and MVP hardening.
+  - REFACTOR: trimmed the roadmap language to phase-level responsibilities and verification gates so it stays readable without turning into per-branch implementation specs.
+- Fix / rework:
+  - user review showed that the first roadmap draft still read too much like `one phase = one branch`
+  - revised the roadmap so phases are milestone groupings and each phase can contain multiple smaller branches
+  - reduced Phase 2 to one focused design-foundation branch
+  - merged the earlier landing/dashboard phases into one surface-refresh phase with two branches
+  - kept landing-first as the preferred order, while noting that parallel execution is only safe if the design foundation is already stable
+  - renamed later phase titles and branch slugs to make single-branch intent easier to scan
+  - split the account phase into auth entry, app shell, and profile concerns
+  - reshaped the board foundation phase into create/list/detail-shell work rather than editing UI
+  - recorded the MVP board-screen decision that the default board surface is the normal view and a separate read-only mode is not required by default
+- Verify:
+  - `pnpm exec prettier --write 'docs/MASTER-PLAN.md'` -> pass
+  - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md` -> pass, roadmap markers found
+  - `git diff --check -- 'docs/MASTER-PLAN.md'` -> pass
+  - `rg -n "Phase Model|Phase 2 - Design Foundation Refresh|Phase 3 - Surface Refresh|Phase 4 - Account Foundation|Phase 5 - Board Foundation|Phase 6 - Board Editing|read-only|app-shell-route-guard|board-domain-foundation|boards-page|cell-detail-flow|board-save-flow" docs/MASTER-PLAN.md` -> pass, revised roadmap markers found
+- Task checklist:
+  - complete
+- Slice checkpoint:
+  - required
+  - approval state: approved by user on 2026-03-17 before commit

--- a/.agent/sessions/[#11]docs--define-project-master-plan/plan.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/plan.md
@@ -1,0 +1,182 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-architecture-rules`
+- Secondary skill lens: `frontend-design`
+
+## Scope
+
+- In:
+  - create `docs/MASTER-PLAN.md` as the canonical English master-plan document
+  - document the current baseline, fixed identity constraints, document map, execution principles, and branch roadmap
+  - treat the branch roadmap and sequencing guidance as the primary deliverable
+  - keep non-roadmap sections concise and only detailed enough to support the roadmap
+  - translate the accepted master plan into `docs/ko/MASTER-PLAN.md` if the English source is finalized in this branch
+  - make only minimal source-of-truth cross-reference updates if a concrete clarity gap appears during execution
+- Out:
+  - landing/dashboard UI implementation changes
+  - feature implementation
+  - broad rewrites to the existing core docs unrelated to the master-plan document
+
+## Interface / Type Changes
+
+- No runtime interface or TypeScript contract changes are planned.
+- New document surfaces:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md` after English finalization
+
+## Slice 1
+
+- Goal:
+  - Create the English master-plan skeleton and lock the branch baseline, document role, and fixed identity constraints.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` explicitly positions itself above `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and `AGENTS`
+  - the document records the current implementation baseline rather than describing a greenfield project
+  - the document preserves service name, color direction, token system, and memo/paper concept as fixed constraints
+- Out of scope:
+  - detailed branch-by-branch roadmap content beyond the initial section placeholders
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Write the document purpose and source-of-truth relationship.
+  2. Summarize the current repository baseline and completed branch foundations.
+  3. Record the fixed design and architecture constraints that future branches must preserve.
+  4. Add the high-level section skeleton for the remaining master-plan content.
+- RED:
+  - Compare the accepted spec and research conclusions against the missing `docs/MASTER-PLAN.md`; fail on absent baseline, missing document role, and missing fixed-constraint statements.
+- GREEN:
+  - Add the minimum English sections needed to satisfy the baseline, role, and fixed-constraint requirements.
+- REFACTOR:
+  - Tighten wording, remove duplicated statements from adjacent sections, and ensure the document stays above detailed PRD/tech content.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Current Baseline|Fixed Constraints|Source of Truth|Roadmap" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the draft starts duplicating PRD or TECH_REFERENCE detail, trim back to summary language and link responsibilities to the owning docs before continuing.
+- Commit:
+  - `:memo: docs: add master plan baseline and constraints`
+
+## Slice 2
+
+- Goal:
+  - Add only the minimum planning-level product, UX, architecture, and branch-delivery principles needed to make the roadmap unambiguous.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the document captures only the planning-level guidance needed to interpret the roadmap for product scope, UX direction, design-system continuity, and server/client architecture boundaries
+  - the content points detailed ownership back to the existing source docs instead of duplicating them
+  - the master plan explains how issue-per-branch and thread-per-branch execution should operate
+- Out of scope:
+  - detailed branch sequencing tables
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Add planning-level product and UX direction sections.
+  2. Add architecture and document-ownership guidance tied back to the core docs.
+  3. Add branch-cycle and execution-principle guidance for future branches.
+  4. Check that no section drifts into low-value duplication.
+- RED:
+  - Check the slice 1 draft against spec acceptance criteria and fail on missing planning rules for product direction, document ownership, and branch execution.
+- GREEN:
+  - Add the minimum planning-level sections needed to cover those missing rules.
+- REFACTOR:
+  - Merge overlapping guidance, simplify repetitive language, and cut any section content that is not necessary to support the roadmap.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Product Direction|UX Direction|Architecture Principles|Branch Delivery" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If section boundaries blur, rewrite the headings so each section owns one planning responsibility and defer detailed specifics to the owning doc.
+- Commit:
+  - `:memo: docs: define master plan operating principles`
+
+## Slice 3
+
+- Goal:
+  - Define the branch-by-branch roadmap, recommended sequence, dependency logic, and verification expectations from the current state through MVP delivery as the primary output of the branch.
+- Binding skill lens:
+  - `frontend-design`
+- Done criteria:
+  - the roadmap names the recommended next branches in order
+  - the roadmap explains where UI refresh branches fit and why they happen at that stage
+  - each roadmap stage states its responsibility and what must be true before the next stage
+  - the roadmap stays at planning level rather than becoming a full per-branch implementation spec
+  - the roadmap carries more decision weight than the surrounding explanatory sections
+- Out of scope:
+  - writing future branch-local specs or plans
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Define the roadmap stages from current docs baseline to MVP completion.
+  2. Group the roadmap into docs, UI refresh, platform/app-shell, feature delivery, and hardening phases.
+  3. Add dependencies and verification expectations for each phase.
+  4. Check that the roadmap preserves the fixed identity constraints through the planned UI refresh.
+  5. Trim or simplify surrounding sections if they distract from the roadmap as the document's main deliverable.
+- RED:
+  - Compare the draft against the accepted research recommendation and fail on missing sequence logic, missing UI refresh placement, or missing dependency explanations.
+- GREEN:
+  - Add the roadmap table or structured list with the minimum information required to remove sequencing ambiguity.
+- REFACTOR:
+  - Compress repetitive roadmap entries, normalize wording across stages, and remove branch detail that belongs in future branch-local plans.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the roadmap becomes too implementation-specific, step back to milestone-level responsibilities and move branch-local detail out of the master plan.
+- Commit:
+  - `:memo: docs: add master plan branch roadmap`
+
+## Slice 4
+
+- Goal:
+  - Finalize the English source, sync the Korean translation, and apply only the minimal cross-reference touch-ups required for document clarity after the roadmap-heavy draft is accepted.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` is final for this branch
+  - `docs/ko/MASTER-PLAN.md` matches the accepted English source if translation is included
+  - any supporting doc touch-ups stay minimal and do not widen branch scope
+- Out of scope:
+  - unrelated edits in existing docs
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md`
+  - one additional source doc only if a concrete cross-reference gap is found during execution; otherwise none
+- User checkpoint: `not required`
+- Task checklist:
+  1. Review the English source for consistency and terminology drift.
+  2. Translate the finalized content into Korean.
+  3. Apply only necessary cross-reference touch-ups if a specific clarity gap is confirmed.
+  4. Run final document verification commands.
+- RED:
+  - Check the near-final English source and fail on unresolved wording conflicts, unsynced translation, or source-of-truth ambiguity.
+- GREEN:
+  - Apply the minimal edits needed to finalize the English source, add the Korean translation, and close confirmed cross-reference gaps.
+- REFACTOR:
+  - Tighten translation consistency, normalize headings, and remove stray duplication across the touched docs.
+- Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check -- docs/MASTER-PLAN.md docs/ko/MASTER-PLAN.md`
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko`
+- Failure recovery:
+  - If translation reveals unresolved English-source ambiguity, fix the English source first, then re-sync Korean instead of patching around the mismatch.
+- Commit:
+  - `:memo: docs: finalize and sync master plan`
+
+## Final Stages
+
+- Hardening:
+  - check for terminology drift, duplicated ownership statements, stale path references, and roadmap entries that contradict the current baseline or core docs
+- Review:
+  - run a doc-focused review for scope creep, source-of-truth confusion, weak sequencing logic, and any roadmap step that cannot be justified from the current baseline
+- Refactor:
+  - apply only wording, structure, or cross-reference fixes justified by hardening or review findings
+- Final Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check`
+  - `rg -n "docs/MASTER-PLAN.md|docs/ko/MASTER-PLAN.md|\\.agent/sessions" AGENTS.md docs/*.md docs/ko/*.md`

--- a/.agent/sessions/[#11]docs--define-project-master-plan/plans/01-branch-baseline.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/plans/01-branch-baseline.md
@@ -1,0 +1,178 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-architecture-rules`
+- Secondary skill lens: `frontend-design`
+
+## Scope
+
+- In:
+  - create `docs/MASTER-PLAN.md` as the canonical English master-plan document
+  - document the current baseline, fixed identity constraints, document map, execution principles, and branch roadmap
+  - translate the accepted master plan into `docs/ko/MASTER-PLAN.md` if the English source is finalized in this branch
+  - make only minimal source-of-truth cross-reference updates if a concrete clarity gap appears during execution
+- Out:
+  - landing/dashboard UI implementation changes
+  - feature implementation
+  - broad rewrites to the existing core docs unrelated to the master-plan document
+
+## Interface / Type Changes
+
+- No runtime interface or TypeScript contract changes are planned.
+- New document surfaces:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md` after English finalization
+
+## Slice 1
+
+- Goal:
+  - Create the English master-plan skeleton and lock the branch baseline, document role, and fixed identity constraints.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` explicitly positions itself above `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and `AGENTS`
+  - the document records the current implementation baseline rather than describing a greenfield project
+  - the document preserves service name, color direction, token system, and memo/paper concept as fixed constraints
+- Out of scope:
+  - detailed branch-by-branch roadmap content beyond the initial section placeholders
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Write the document purpose and source-of-truth relationship.
+  2. Summarize the current repository baseline and completed branch foundations.
+  3. Record the fixed design and architecture constraints that future branches must preserve.
+  4. Add the high-level section skeleton for the remaining master-plan content.
+- RED:
+  - Compare the accepted spec and research conclusions against the missing `docs/MASTER-PLAN.md`; fail on absent baseline, missing document role, and missing fixed-constraint statements.
+- GREEN:
+  - Add the minimum English sections needed to satisfy the baseline, role, and fixed-constraint requirements.
+- REFACTOR:
+  - Tighten wording, remove duplicated statements from adjacent sections, and ensure the document stays above detailed PRD/tech content.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Current Baseline|Fixed Constraints|Source of Truth|Roadmap" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the draft starts duplicating PRD or TECH_REFERENCE detail, trim back to summary language and link responsibilities to the owning docs before continuing.
+- Commit:
+  - `:memo: docs: add master plan baseline and constraints`
+
+## Slice 2
+
+- Goal:
+  - Add the planning-level product, UX, architecture, and branch-delivery principles that the roadmap must obey.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the document captures planning-level guidance for product scope, UX direction, design-system continuity, and server/client architecture boundaries
+  - the content points detailed ownership back to the existing source docs instead of duplicating them
+  - the master plan explains how issue-per-branch and thread-per-branch execution should operate
+- Out of scope:
+  - detailed branch sequencing tables
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Add planning-level product and UX direction sections.
+  2. Add architecture and document-ownership guidance tied back to the core docs.
+  3. Add branch-cycle and execution-principle guidance for future branches.
+  4. Check that no section drifts into low-value duplication.
+- RED:
+  - Check the slice 1 draft against spec acceptance criteria and fail on missing planning rules for product direction, document ownership, and branch execution.
+- GREEN:
+  - Add the minimum planning-level sections needed to cover those missing rules.
+- REFACTOR:
+  - Merge overlapping guidance, simplify repetitive language, and keep section boundaries explicit.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Product Direction|UX Direction|Architecture Principles|Branch Delivery" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If section boundaries blur, rewrite the headings so each section owns one planning responsibility and defer detailed specifics to the owning doc.
+- Commit:
+  - `:memo: docs: define master plan operating principles`
+
+## Slice 3
+
+- Goal:
+  - Define the branch-by-branch roadmap, recommended sequence, dependency logic, and verification expectations from the current state through MVP delivery.
+- Binding skill lens:
+  - `frontend-design`
+- Done criteria:
+  - the roadmap names the recommended next branches in order
+  - the roadmap explains where UI refresh branches fit and why they happen at that stage
+  - each roadmap stage states its responsibility and what must be true before the next stage
+  - the roadmap stays at planning level rather than becoming a full per-branch implementation spec
+- Out of scope:
+  - writing future branch-local specs or plans
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Define the roadmap stages from current docs baseline to MVP completion.
+  2. Group the roadmap into docs, UI refresh, platform/app-shell, feature delivery, and hardening phases.
+  3. Add dependencies and verification expectations for each phase.
+  4. Check that the roadmap preserves the fixed identity constraints through the planned UI refresh.
+- RED:
+  - Compare the draft against the accepted research recommendation and fail on missing sequence logic, missing UI refresh placement, or missing dependency explanations.
+- GREEN:
+  - Add the roadmap table or structured list with the minimum information required to remove sequencing ambiguity.
+- REFACTOR:
+  - Compress repetitive roadmap entries, normalize wording across stages, and remove branch detail that belongs in future branch-local plans.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the roadmap becomes too implementation-specific, step back to milestone-level responsibilities and move branch-local detail out of the master plan.
+- Commit:
+  - `:memo: docs: add master plan branch roadmap`
+
+## Slice 4
+
+- Goal:
+  - Finalize the English source, sync the Korean translation, and apply only the minimal cross-reference touch-ups required for document clarity.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` is final for this branch
+  - `docs/ko/MASTER-PLAN.md` matches the accepted English source if translation is included
+  - any supporting doc touch-ups stay minimal and do not widen branch scope
+- Out of scope:
+  - unrelated edits in existing docs
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md`
+  - one additional source doc only if a concrete cross-reference gap is found during execution; otherwise none
+- User checkpoint: `not required`
+- Task checklist:
+  1. Review the English source for consistency and terminology drift.
+  2. Translate the finalized content into Korean.
+  3. Apply only necessary cross-reference touch-ups if a specific clarity gap is confirmed.
+  4. Run final document verification commands.
+- RED:
+  - Check the near-final English source and fail on unresolved wording conflicts, unsynced translation, or source-of-truth ambiguity.
+- GREEN:
+  - Apply the minimal edits needed to finalize the English source, add the Korean translation, and close confirmed cross-reference gaps.
+- REFACTOR:
+  - Tighten translation consistency, normalize headings, and remove stray duplication across the touched docs.
+- Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check -- docs/MASTER-PLAN.md docs/ko/MASTER-PLAN.md`
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko`
+- Failure recovery:
+  - If translation reveals unresolved English-source ambiguity, fix the English source first, then re-sync Korean instead of patching around the mismatch.
+- Commit:
+  - `:memo: docs: finalize and sync master plan`
+
+## Final Stages
+
+- Hardening:
+  - check for terminology drift, duplicated ownership statements, stale path references, and roadmap entries that contradict the current baseline or core docs
+- Review:
+  - run a doc-focused review for scope creep, source-of-truth confusion, weak sequencing logic, and any roadmap step that cannot be justified from the current baseline
+- Refactor:
+  - apply only wording, structure, or cross-reference fixes justified by hardening or review findings
+- Final Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check`
+  - `rg -n "docs/MASTER-PLAN.md|docs/ko/MASTER-PLAN.md|\\.agent/sessions" AGENTS.md docs/*.md docs/ko/*.md`

--- a/.agent/sessions/[#11]docs--define-project-master-plan/plans/02-roadmap-priority.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/plans/02-roadmap-priority.md
@@ -1,0 +1,182 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-architecture-rules`
+- Secondary skill lens: `frontend-design`
+
+## Scope
+
+- In:
+  - create `docs/MASTER-PLAN.md` as the canonical English master-plan document
+  - document the current baseline, fixed identity constraints, document map, execution principles, and branch roadmap
+  - treat the branch roadmap and sequencing guidance as the primary deliverable
+  - keep non-roadmap sections concise and only detailed enough to support the roadmap
+  - translate the accepted master plan into `docs/ko/MASTER-PLAN.md` if the English source is finalized in this branch
+  - make only minimal source-of-truth cross-reference updates if a concrete clarity gap appears during execution
+- Out:
+  - landing/dashboard UI implementation changes
+  - feature implementation
+  - broad rewrites to the existing core docs unrelated to the master-plan document
+
+## Interface / Type Changes
+
+- No runtime interface or TypeScript contract changes are planned.
+- New document surfaces:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md` after English finalization
+
+## Slice 1
+
+- Goal:
+  - Create the English master-plan skeleton and lock the branch baseline, document role, and fixed identity constraints.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` explicitly positions itself above `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and `AGENTS`
+  - the document records the current implementation baseline rather than describing a greenfield project
+  - the document preserves service name, color direction, token system, and memo/paper concept as fixed constraints
+- Out of scope:
+  - detailed branch-by-branch roadmap content beyond the initial section placeholders
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Write the document purpose and source-of-truth relationship.
+  2. Summarize the current repository baseline and completed branch foundations.
+  3. Record the fixed design and architecture constraints that future branches must preserve.
+  4. Add the high-level section skeleton for the remaining master-plan content.
+- RED:
+  - Compare the accepted spec and research conclusions against the missing `docs/MASTER-PLAN.md`; fail on absent baseline, missing document role, and missing fixed-constraint statements.
+- GREEN:
+  - Add the minimum English sections needed to satisfy the baseline, role, and fixed-constraint requirements.
+- REFACTOR:
+  - Tighten wording, remove duplicated statements from adjacent sections, and ensure the document stays above detailed PRD/tech content.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Current Baseline|Fixed Constraints|Source of Truth|Roadmap" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the draft starts duplicating PRD or TECH_REFERENCE detail, trim back to summary language and link responsibilities to the owning docs before continuing.
+- Commit:
+  - `:memo: docs: add master plan baseline and constraints`
+
+## Slice 2
+
+- Goal:
+  - Add only the minimum planning-level product, UX, architecture, and branch-delivery principles needed to make the roadmap unambiguous.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the document captures only the planning-level guidance needed to interpret the roadmap for product scope, UX direction, design-system continuity, and server/client architecture boundaries
+  - the content points detailed ownership back to the existing source docs instead of duplicating them
+  - the master plan explains how issue-per-branch and thread-per-branch execution should operate
+- Out of scope:
+  - detailed branch sequencing tables
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Add planning-level product and UX direction sections.
+  2. Add architecture and document-ownership guidance tied back to the core docs.
+  3. Add branch-cycle and execution-principle guidance for future branches.
+  4. Check that no section drifts into low-value duplication.
+- RED:
+  - Check the slice 1 draft against spec acceptance criteria and fail on missing planning rules for product direction, document ownership, and branch execution.
+- GREEN:
+  - Add the minimum planning-level sections needed to cover those missing rules.
+- REFACTOR:
+  - Merge overlapping guidance, simplify repetitive language, and cut any section content that is not necessary to support the roadmap.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Product Direction|UX Direction|Architecture Principles|Branch Delivery" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If section boundaries blur, rewrite the headings so each section owns one planning responsibility and defer detailed specifics to the owning doc.
+- Commit:
+  - `:memo: docs: define master plan operating principles`
+
+## Slice 3
+
+- Goal:
+  - Define the branch-by-branch roadmap, recommended sequence, dependency logic, and verification expectations from the current state through MVP delivery as the primary output of the branch.
+- Binding skill lens:
+  - `frontend-design`
+- Done criteria:
+  - the roadmap names the recommended next branches in order
+  - the roadmap explains where UI refresh branches fit and why they happen at that stage
+  - each roadmap stage states its responsibility and what must be true before the next stage
+  - the roadmap stays at planning level rather than becoming a full per-branch implementation spec
+  - the roadmap carries more decision weight than the surrounding explanatory sections
+- Out of scope:
+  - writing future branch-local specs or plans
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+- User checkpoint: `required`
+- Task checklist:
+  1. Define the roadmap stages from current docs baseline to MVP completion.
+  2. Group the roadmap into docs, UI refresh, platform/app-shell, feature delivery, and hardening phases.
+  3. Add dependencies and verification expectations for each phase.
+  4. Check that the roadmap preserves the fixed identity constraints through the planned UI refresh.
+  5. Trim or simplify surrounding sections if they distract from the roadmap as the document's main deliverable.
+- RED:
+  - Compare the draft against the accepted research recommendation and fail on missing sequence logic, missing UI refresh placement, or missing dependency explanations.
+- GREEN:
+  - Add the roadmap table or structured list with the minimum information required to remove sequencing ambiguity.
+- REFACTOR:
+  - Compress repetitive roadmap entries, normalize wording across stages, and remove branch detail that belongs in future branch-local plans.
+- Verify:
+  - `pnpm prettier:docs`
+  - `rg -n "Roadmap|Phase|Dependency|Verification" docs/MASTER-PLAN.md`
+- Failure recovery:
+  - If the roadmap becomes too implementation-specific, step back to milestone-level responsibilities and move branch-local detail out of the master plan.
+- Commit:
+  - `:memo: docs: add master plan branch roadmap`
+
+## Slice 4
+
+- Goal:
+  - Finalize the English source, sync the Korean translation, and apply only the minimal cross-reference touch-ups required for document clarity after the roadmap-heavy draft is accepted.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `docs/MASTER-PLAN.md` is final for this branch
+  - `docs/ko/MASTER-PLAN.md` matches the accepted English source if translation is included
+  - any supporting doc touch-ups stay minimal and do not widen branch scope
+- Out of scope:
+  - unrelated edits in existing docs
+- Planned files:
+  - `docs/MASTER-PLAN.md`
+  - `docs/ko/MASTER-PLAN.md`
+  - one additional source doc only if a concrete cross-reference gap is found during execution; otherwise none
+- User checkpoint: `not required`
+- Task checklist:
+  1. Review the English source for consistency and terminology drift.
+  2. Translate the finalized content into Korean.
+  3. Apply only necessary cross-reference touch-ups if a specific clarity gap is confirmed.
+  4. Run final document verification commands.
+- RED:
+  - Check the near-final English source and fail on unresolved wording conflicts, unsynced translation, or source-of-truth ambiguity.
+- GREEN:
+  - Apply the minimal edits needed to finalize the English source, add the Korean translation, and close confirmed cross-reference gaps.
+- REFACTOR:
+  - Tighten translation consistency, normalize headings, and remove stray duplication across the touched docs.
+- Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check -- docs/MASTER-PLAN.md docs/ko/MASTER-PLAN.md`
+  - `rg -n "MASTER-PLAN|Master Plan|마스터 플랜" docs docs/ko`
+- Failure recovery:
+  - If translation reveals unresolved English-source ambiguity, fix the English source first, then re-sync Korean instead of patching around the mismatch.
+- Commit:
+  - `:memo: docs: finalize and sync master plan`
+
+## Final Stages
+
+- Hardening:
+  - check for terminology drift, duplicated ownership statements, stale path references, and roadmap entries that contradict the current baseline or core docs
+- Review:
+  - run a doc-focused review for scope creep, source-of-truth confusion, weak sequencing logic, and any roadmap step that cannot be justified from the current baseline
+- Refactor:
+  - apply only wording, structure, or cross-reference fixes justified by hardening or review findings
+- Final Verify:
+  - `pnpm prettier:docs`
+  - `git diff --check`
+  - `rg -n "docs/MASTER-PLAN.md|docs/ko/MASTER-PLAN.md|\\.agent/sessions" AGENTS.md docs/*.md docs/ko/*.md`

--- a/.agent/sessions/[#11]docs--define-project-master-plan/research.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/research.md
@@ -1,0 +1,134 @@
+# Research
+
+## Goal
+
+- Reduce planning uncertainty for `docs/MASTER-PLAN.md` by fixing:
+  - the current project baseline the document must describe
+  - the right structure and role for the master plan
+  - the recommended sequence for the follow-up branches
+
+## Research Questions
+
+- What current repository baseline and completed branch history must the master plan explicitly anchor on?
+- What structure lets `docs/MASTER-PLAN.md` guide execution without duplicating `docs/PRD.md`, `docs/SCAFFOLD_STRUCTURE.md`, or `docs/TECH_REFERENCE.md`?
+- Where should the planned UI refresh sit in the roadmap if service identity, token rules, and the memo/paper concept must be preserved?
+
+## Scope
+
+- In:
+  - local evidence from the current docs, UI baseline, token system, and git history
+  - structure options for `docs/MASTER-PLAN.md`
+  - sequence options for the first set of follow-up branches
+- Out:
+  - implementing UI changes
+  - feature-level technical design deeper than needed for branch ordering
+  - rewriting product requirements already owned by `PRD`
+
+## Current Baseline
+
+- Source-of-truth documents are already aligned:
+  - `AGENTS.md` defines project-wide rules and branch-cycle expectations
+  - `docs/PRD.md` defines product scope and MVP targets
+  - `docs/SCAFFOLD_STRUCTURE.md` defines the FSD-lite scaffold and boundary rules
+  - `docs/TECH_REFERENCE.md` defines the technical implementation baseline
+- Previous branch handoff for [#9] documents that the next work should start a new docs branch for `docs/MASTER-PLAN.md`.
+- Git history shows the project is not at a greenfield stage:
+  - setup and toolchain foundation already landed
+  - theme/color work landed in `feat/1--color`
+  - shared shadcn/ui foundation landed in `ui/3--shadcn-components`
+  - landing page work landed in `ui/5--landing-page`
+  - dashboard page work landed in `ui/7--dashboard-page`
+  - docs alignment landed in `docs/9--update-agentic-docs`
+- Current UI evidence confirms the identity constraints are concrete, not abstract:
+  - `src/app/globals.css` defines the warm paper-like brand palette and semantic tokens
+  - landing and dashboard widgets use paper/tape/card treatments and memo-like visual language
+  - the service is framed around Mandalart planning, not a generic productivity dashboard
+
+## Constraints
+
+- The master plan must sit above, not replace, the existing source-of-truth documents.
+- The branch must preserve the user's fixed identity constraints:
+  - same service name
+  - same color direction
+  - same semantic design-token contract
+  - same memo/note-taking concept
+- The roadmap must fit the issue-per-branch and thread-per-branch workflow.
+- The branch should not assume the current landing and dashboard UI are final, but it must recognize them as the active implementation baseline.
+
+## Options Considered
+
+### Option 1: Product-Roadmap-Only Document
+
+- Focus the master plan mostly on product milestones, MVP scope, and future features.
+- Leave architecture and document ownership in the existing docs.
+
+### Option 2: Architecture-Charter Document
+
+- Focus the master plan on technical boundaries, document ownership, and implementation rules.
+- Leave branch sequencing and UI refresh strategy mostly implicit.
+
+### Option 3: Hybrid Delivery Master Plan
+
+- Combine:
+  - current baseline summary
+  - fixed product and design constraints
+  - document map and ownership
+  - execution principles
+  - branch-by-branch roadmap with sequencing and dependency logic
+- Keep detailed product requirements, scaffold rules, and technical reference material in the existing source docs.
+
+## Evidence
+
+- `AGENTS.md` explicitly says the core project docs remain the source of truth, and that non-trivial work follows the branch cycle.
+- `docs/PRD.md` already defines MVP scope, user flow, dashboard/export goals, and product targets.
+- `docs/SCAFFOLD_STRUCTURE.md` already defines layer boundaries, UI surface separation, and data-access rules.
+- `docs/TECH_REFERENCE.md` already defines toolchain, schema, RLS, and query-key conventions.
+- Previous handoff states that the next branch should write `docs/MASTER-PLAN.md`, use the current docs as required inputs, preserve service name/color/token/memo direction, and treat the UI refresh as a likely follow-up branch.
+- Git history shows a logical sequence already exists in practice:
+  - setup and theme foundation before shared UI
+  - shared UI before landing
+  - landing before dashboard
+  - docs alignment before writing the master plan
+- Current UI components show an established visual language:
+  - paper/card surfaces
+  - tape decorations
+  - warm token-backed palette
+  - planning-board and note-like affordances
+
+## Recommendation
+
+- Use **Option 3: Hybrid Delivery Master Plan**.
+- Structure `docs/MASTER-PLAN.md` around these top-level sections:
+  1. Purpose and relationship to the other source-of-truth docs
+  2. Current project baseline
+  3. Fixed identity and architecture constraints
+  4. Product and UX direction at a planning level
+  5. Execution principles for branch-based delivery
+  6. Branch roadmap and sequencing
+  7. Verification strategy and document-sync rules
+  8. Risks, decision checkpoints, and deferred items
+- Place the planned UI refresh early in the roadmap, but after the master plan is accepted and before deeper feature implementation expands the visual surface area.
+- Treat the UI refresh as a sequence of dedicated UI branches, not as incidental cleanup inside feature branches.
+
+## Tradeoffs
+
+- Option 1 would be shorter, but it would not resolve the real planning gap: how to connect the existing docs to actual branch execution.
+- Option 2 would improve architecture clarity, but it would leave the product delivery order and UI refresh timing under-specified.
+- Option 3 is larger and needs discipline to avoid duplication, but it best matches the branch goal and current repository maturity.
+
+## Open Questions
+
+- Whether the roadmap should include a short post-MVP horizon or stop strictly at MVP.
+- Whether Korean translation should land in the same cycle or after the English source stabilizes through review.
+
+## Planning Impact
+
+- Recommended primary classification: `react-ui`
+- Recommended secondary classification: `next-app-router`
+- Recommended primary skill lens: `frontend-architecture-rules`
+- Recommended secondary skill lens: `frontend-design`
+- The plan should preserve these constraints:
+  - `docs/MASTER-PLAN.md` must not duplicate detailed source-of-truth content that already belongs in PRD, scaffold, or tech docs
+  - the roadmap must be written from the current repository baseline, not from scratch
+  - the UI refresh must be documented as a deliberate follow-up branch sequence that preserves existing identity constraints
+  - English source writing and Korean sync should be separate slices

--- a/.agent/sessions/[#11]docs--define-project-master-plan/spec.md
+++ b/.agent/sessions/[#11]docs--define-project-master-plan/spec.md
@@ -1,0 +1,99 @@
+# Spec
+
+## Goal
+
+- Write `docs/MASTER-PLAN.md` as the canonical English master-plan document for Mandalart Web.
+- Fix the project's current baseline, non-negotiable identity constraints, and branch-by-branch execution order so future issue-driven branches can plan and execute against one shared reference.
+
+## Problem / Background
+
+- The repository now has aligned core source-of-truth documents in `docs/PRD.md`, `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and project-wide operating rules in `AGENTS.md`, but it still lacks a top-level master-plan document that explains how those documents connect and how the project should be delivered from the current baseline.
+- The current implementation baseline is no longer hypothetical:
+  - project setup is already in place
+  - the brand token system is established in `src/app/globals.css`
+  - the landing UI exists from the earlier landing-page branch history
+  - the dashboard UI exists from the earlier dashboard-page branch history
+- The user wants the next phase of the project to preserve the service identity, color direction, semantic design-token system, and memo/note-taking concept while allowing a fresh UI pass using the newly installed skills.
+- Without a master plan, future issue-per-branch work can drift on scope, sequencing, document ownership, and how the UI refresh should relate to MVP feature delivery.
+
+## Desired Outcome
+
+- `docs/MASTER-PLAN.md` exists as a clear top-level planning document that:
+  - makes the branch roadmap and execution order the primary output of the document
+  - describes the current project baseline and fixed constraints
+  - explains the role of `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and branch artifacts
+  - defines the recommended branch roadmap from the current UI baseline to MVP completion
+  - clarifies what should be preserved versus redesigned in follow-up UI branches
+  - gives future branch specs and plans a stable reference for sequencing and scope control
+- The branch may also produce `docs/ko/MASTER-PLAN.md` after the English source is finalized.
+
+## Scope
+
+- In:
+  - write the English source document at `docs/MASTER-PLAN.md`
+  - document the current implementation baseline and delivery assumptions
+  - define the master-plan structure and the information categories it must cover
+  - define a branch-by-branch roadmap, execution order, and dependency logic
+  - record the fixed brand and design constraints that follow-up UI branches must preserve
+  - add Korean translation sync for the master plan after the English source is accepted
+  - make small cross-reference adjustments in existing docs only if they are necessary to keep source-of-truth relationships clear
+- Out:
+  - implementing the UI refresh itself
+  - changing landing or dashboard UI code in this branch
+  - changing the service name, replacing the current token system, or redefining the visual identity from scratch
+  - implementing auth, board editing, dashboard data integration, export, or other product features
+  - large rewrites of `PRD`, `SCAFFOLD_STRUCTURE`, or `TECH_REFERENCE` beyond small alignment edits caused directly by the new master plan
+
+## Non-Goals
+
+- Producing feature implementation code
+- Finalizing every detailed requirement for every future branch
+- Replacing the existing core source-of-truth documents with a single monolithic document
+- Using this branch to redesign the product UI directly
+
+## Constraints / Assumptions
+
+- This branch must follow the documented branch cycle: `Spec -> Research -> Planner -> Execution -> Hardening -> Review -> Refactor -> Final Verify`.
+- English documents under `docs/*.md` remain the source of truth; Korean sync happens only after the English source is finalized.
+- The master plan must preserve the already agreed design identity:
+  - service name stays the same
+  - current color direction remains the base direction
+  - semantic design tokens in `src/app/globals.css` remain the shared styling contract
+  - the memo/paper/note-taking concept remains part of the product identity
+- The master plan must treat the current repository state as a real baseline, not a greenfield project:
+  - project setup exists
+  - landing page UI exists
+  - dashboard page UI exists
+- Each future branch continues to map to one issue and one working thread.
+- Existing unrelated worktree changes in `.github/workflows/playwright.yml` and `pnpm-lock.yaml` are not part of this branch unless explicitly requested later.
+
+## Acceptance Criteria
+
+- `docs/MASTER-PLAN.md` is written as a top-level planning document and explicitly positions itself relative to `docs/PRD.md`, `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`.
+- The document records the current implementation baseline, including setup completion and the existing landing/dashboard UI state.
+- The document clearly separates:
+  - what is fixed and must be preserved
+  - what is open for redesign or future implementation
+- The document includes a branch roadmap with recommended execution order, branch responsibilities, and dependency logic from the current state toward MVP delivery.
+- The roadmap explains where the planned UI refresh fits and why it should occur in that sequence.
+- The roadmap is the primary value of the document; non-roadmap sections stay concise and provide only the context needed to interpret and apply the roadmap.
+- The document is specific enough that a future issue-driven branch can derive its branch-local `spec.md` and `plan.md` without redefining project-wide fundamentals.
+- If Korean translation is included in this branch, `docs/ko/MASTER-PLAN.md` is synchronized with the finalized English source.
+
+## Open Questions
+
+- Should the roadmap stop at MVP delivery or include a short post-MVP branch horizon as context?
+- How much detail should each roadmap branch carry inside the master plan before it becomes too close to branch-local planning?
+- Should Korean translation land in the same branch after English finalization, or be deferred if the English document still needs iteration?
+
+## Research Decision
+
+- Required: yes
+- Why:
+  - the branch needs a decision-ready structure for `docs/MASTER-PLAN.md` so it does not duplicate or dilute the existing core documents
+  - the roadmap must reflect the actual implementation baseline and branch history, not a generic greenfield sequence
+  - the placement and scope of the planned UI refresh need to be justified before planning slices
+- If yes, research questions:
+  - What current repository baseline and completed branch history must the master plan explicitly anchor on?
+  - What document structure best connects `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`, and branch-cycle artifacts without turning the master plan into a duplicate PRD?
+  - How should the branch roadmap sequence documentation, UI refresh, and MVP feature branches so the preserved identity constraints survive the redesign work?

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -1,0 +1,169 @@
+# Mandalart Web - MASTER PLAN (v0.1)
+
+_Last updated: 2026-03-15 (KST)_
+
+---
+
+## 1) Purpose
+
+This document is the top-level delivery plan for Mandalart Web.
+It exists to connect the current source-of-truth documents, fix the active project baseline, and define how future issue-driven branches should move from the current state toward MVP completion.
+
+This document does **not** replace the core documents:
+
+- `docs/PRD.md` still owns product goals, scope, and functional requirements
+- `docs/SCAFFOLD_STRUCTURE.md` still owns scaffold, layer, and file-placement rules
+- `docs/TECH_REFERENCE.md` still owns technical implementation details
+- `AGENTS.md` still owns always-on project and workflow rules
+
+This master plan owns what sits above those documents:
+
+- the current delivery baseline
+- non-negotiable project constraints
+- the order in which future branches should be executed
+- the checkpoints that keep branch work aligned with the project identity and architecture
+
+---
+
+## 2) Source-of-Truth Map
+
+Use the project documents in this order when planning or executing future branches:
+
+1. `docs/MASTER-PLAN.md`
+   - delivery baseline
+   - branch roadmap
+   - cross-document usage order
+   - project-level decision checkpoints
+2. `docs/PRD.md`
+   - product goals
+   - MVP scope
+   - user-facing requirements
+3. `docs/SCAFFOLD_STRUCTURE.md`
+   - app structure
+   - layer boundaries
+   - UI surface ownership
+4. `docs/TECH_REFERENCE.md`
+   - toolchain
+   - schema and data details
+   - technical implementation conventions
+5. `AGENTS.md`
+   - project-wide AI rules
+   - branch-cycle workflow
+   - documentation sync expectations
+
+Branch-local artifacts under `.agent/sessions/[#<issue-number>]<prefix>--<slug>/` remain the execution record for each branch and should derive their local intent from this master plan plus the owning source docs above.
+
+---
+
+## 3) Current Baseline
+
+The repository should now be treated as an active baseline, not as a greenfield scaffold.
+
+### 3.1 Delivery Baseline
+
+- project setup and toolchain foundation are already in place
+- shared color and theme-token groundwork has already landed
+- shared shadcn/ui foundation is already installed and in use
+- branch-cycle project docs were aligned in the previous docs branch
+
+### 3.2 Product and UI Baseline
+
+- the service identity is already established in the application metadata and current UI
+- the landing page is already implemented
+- the dashboard page is already implemented
+- the product direction is already framed around the Mandalart planning method rather than a generic productivity tool
+
+### 3.3 Visual Baseline
+
+- `src/app/globals.css` already defines the semantic color-token contract
+- the current UI already uses a warm paper-like palette, card surfaces, and memo-like accents
+- existing components already use note-board cues such as tape, pinned-card composition, and planning-board language
+
+### 3.4 Workflow Baseline
+
+- each branch is paired with one issue
+- each branch is worked in its own thread
+- non-trivial work follows the branch cycle under `.agent/sessions/...`
+
+This baseline matters because follow-up branches should refine and extend what exists today instead of planning as though nothing has been built.
+
+---
+
+## 4) Fixed Constraints
+
+These constraints are project-level decisions and should be assumed true unless a later branch explicitly changes them with a documented justification.
+
+### 4.1 Identity Constraints
+
+- Keep the service name and current product identity intact.
+- Keep Mandalart as the core framing method for goal planning and board-based execution.
+- Do not reposition the product as a generic dashboard or generic note-taking app.
+
+### 4.2 Visual-System Constraints
+
+- Preserve the current color direction as the base visual direction.
+- Preserve the semantic token system in `src/app/globals.css` as the shared styling contract.
+- Preserve the memo/paper/note-taking concept as part of the product's visual identity.
+- Future UI refresh work may reinterpret layout, typography, spacing, motion, and composition, but it must not discard the token-backed identity system.
+
+### 4.3 Architecture Constraints
+
+- Keep the current App Router + TypeScript + Prisma + Supabase architecture direction.
+- Keep database access server-side only.
+- Keep Prisma as the primary application data-access layer.
+- Keep Supabase responsible for auth/session, storage, and RLS enforcement.
+- Keep the scaffold aligned to the FSD-lite structure defined in `docs/SCAFFOLD_STRUCTURE.md`.
+
+### 4.4 Workflow Constraints
+
+- Continue using one issue per branch and one thread per branch.
+- Continue using the branch cycle for non-trivial work.
+- Keep English documents under `docs/*.md` as the source of truth.
+- Sync Korean documents only after the English source is finalized.
+
+---
+
+## 5) What This Master Plan Must Clarify
+
+This document should give future branches a stable answer to these project-level questions:
+
+- What is already implemented and should be treated as the active baseline?
+- Which parts of the current identity are fixed and which parts are open for redesign?
+- How should product, UI, and feature work be sequenced from this point forward?
+- Which source document owns which type of decision?
+- What verification and documentation-sync expectations apply as the project moves branch by branch?
+
+The remaining sections of this document will turn those questions into an execution-ready roadmap without duplicating detailed product or technical specification content that already lives elsewhere.
+
+---
+
+## 6) Product and Experience Direction
+
+This section will summarize the planning-level product and UX direction that future branches must preserve while implementing MVP scope.
+It should stay above detailed requirements and defer concrete feature ownership to `docs/PRD.md`.
+
+---
+
+## 7) Architecture and Delivery Principles
+
+This section will summarize the planning-level architecture, UI-surface, and branch-delivery principles that future branches must follow.
+It should defer detailed scaffold and technical rules to `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`.
+
+---
+
+## 8) Branch Roadmap
+
+This section will define the recommended branch-by-branch sequence from the current baseline toward MVP completion.
+It should explain where the UI refresh happens, what each stage is responsible for, and what must be true before the next stage begins.
+
+---
+
+## 9) Verification and Documentation Sync
+
+This section will define how document verification, branch verification, and English/Korean sync should happen as the roadmap advances.
+
+---
+
+## 10) Risks and Decision Checkpoints
+
+This section will capture the main delivery risks, scope boundaries, and the decision points that should trigger a replan instead of ad-hoc drift.

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -139,15 +139,47 @@ The remaining sections of this document will turn those questions into an execut
 
 ## 6) Product and Experience Direction
 
-This section will summarize the planning-level product and UX direction that future branches must preserve while implementing MVP scope.
-It should stay above detailed requirements and defer concrete feature ownership to `docs/PRD.md`.
+The master plan should only define the product and experience direction needed to sequence the work.
+Detailed requirements, field rules, and user-facing acceptance still belong in `docs/PRD.md`.
+
+### 6.1 Product Direction
+
+- Prioritize the MVP flow already described in `docs/PRD.md`:
+  - account-based access
+  - board creation and management
+  - task completion flow
+  - dashboard visibility
+  - export output
+- Treat the current landing and dashboard implementation as baseline surfaces to refine, not disposable experiments.
+- Use the roadmap to move from static or demo-oriented UI surfaces toward real MVP behavior in a controlled order.
+
+### 6.2 UX Direction
+
+- Preserve the memo/paper/planning-board concept across landing, dashboard, and future board-related surfaces.
+- Keep the product legible and structured first; stylistic refresh work should strengthen clarity, hierarchy, and planning flow rather than add ornamental complexity.
+- Make the board flow the core experience and keep the dashboard as a summary and progress surface, not the product's primary editing surface.
+- Keep landing and dashboard refresh work visually aligned so the service identity reads as one system.
 
 ---
 
 ## 7) Architecture and Delivery Principles
 
-This section will summarize the planning-level architecture, UI-surface, and branch-delivery principles that future branches must follow.
-It should defer detailed scaffold and technical rules to `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`.
+The master plan should only restate the architecture and delivery rules that materially affect roadmap order.
+Detailed file-placement and technical implementation rules still belong in `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, and `AGENTS.md`.
+
+### 7.1 Architecture Principles
+
+- Keep database access server-side only, with Prisma as the primary application data-access layer and Supabase responsible for auth, storage, and RLS.
+- Keep the App Router scaffold, layer boundaries, and UI surface separation defined in `docs/SCAFFOLD_STRUCTURE.md`.
+- Reuse installed `shadcn/ui`, existing shared UI, and semantic tokens before introducing new project UI primitives or local color decisions.
+- Keep new work explainable from imports and boundaries; avoid low-value repository, adapter, or wrapper layers.
+
+### 7.2 Branch Delivery
+
+- Keep one issue per branch and one thread per branch.
+- Keep the documented branch cycle for non-trivial work and use branch-local artifacts under `.agent/sessions/...`.
+- Keep UI refresh work in dedicated UI branches instead of hiding it inside deeper feature branches.
+- Update English source docs first when roadmap or architecture guidance changes, then sync Korean documentation afterward.
 
 ---
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -159,6 +159,10 @@ Detailed requirements, field rules, and user-facing acceptance still belong in `
 - Keep the product legible and structured first; stylistic refresh work should strengthen clarity, hierarchy, and planning flow rather than add ornamental complexity.
 - Make the board flow the core experience and keep the dashboard as a summary and progress surface, not the product's primary editing surface.
 - Keep landing and dashboard refresh work visually aligned so the service identity reads as one system.
+- Treat the default board screen as both the overview state and the entry point into editing:
+  - the non-focused board state should already function as the normal board view
+  - selecting a cell should transition into a focused edit surface such as a drawer or side panel
+  - a separate read-only board mode is not required for MVP unless a later branch introduces a concrete sharing or presentation need
 
 ---
 
@@ -185,8 +189,198 @@ Detailed file-placement and technical implementation rules still belong in `docs
 
 ## 8) Branch Roadmap
 
-This section will define the recommended branch-by-branch sequence from the current baseline toward MVP completion.
-It should explain where the UI refresh happens, what each stage is responsible for, and what must be true before the next stage begins.
+The roadmap should optimize for two things at once:
+
+- preserve the current service identity while the UI gets refreshed
+- avoid widening feature implementation before the visual system and app/data foundations are stable
+
+### 8.1 Sequencing Logic
+
+- Complete the top-level planning document first so later branches inherit one baseline and one source-of-truth map.
+- Refresh the shared design foundation before expanding more screens or deeper feature flows.
+- Refresh the landing and dashboard surfaces early because they already exist and define the visible identity of the product.
+- Establish auth and application-shell behavior before user-owned board flows expand.
+- Establish the board domain and editing workflow before wiring real dashboard metrics and export output.
+- Finish with hardening and release-readiness work after the main MVP loop is in place.
+
+### 8.2 Phase Model
+
+- A phase is a delivery milestone, not a required one-branch boundary.
+- Most phases should be executed through `1-3` small branches, each with one main responsibility.
+- Split a phase into multiple branches when one branch would otherwise combine:
+  - shared UI foundation work plus page redesign
+  - auth/session work plus unrelated account surfaces
+  - domain modeling plus multiple pages plus interaction-heavy editing
+- The roadmap below names the recommended phase scope first and the likely branch splits second.
+
+### 8.3 Phase Breakdown
+
+#### Phase 0 - Completed Baseline
+
+- Completed branches:
+  - `feat/1--color`
+  - `ui/3--shadcn-components`
+  - `ui/5--landing-page`
+  - `ui/7--dashboard-page`
+  - `docs/9--update-agentic-docs`
+- Responsibility:
+  - establish the token foundation, shared UI primitives, initial landing/dashboard surfaces, and aligned project docs
+- Verification before moving on:
+  - treat the current repository state as the fixed baseline for future planning
+
+#### Phase 1 - Current Planning Branch
+
+- Current branch:
+  - `docs/11--define-project-master-plan`
+- Responsibility:
+  - finalize the master plan, freeze the delivery order, and keep source-of-truth ownership explicit
+- Verification before moving on:
+  - accepted `docs/MASTER-PLAN.md`
+  - verified session artifacts
+  - final document alignment
+
+#### Phase 2 - Design Foundation Refresh
+
+- Why this phase exists:
+  - landing and dashboard already exist, but the refreshed UI direction should be unified before more feature surfaces are added
+- Recommended branch:
+  - `ui/<n>--refresh-design-foundation`
+    - audit the current visual language
+    - lock the refreshed note/paper direction
+    - implement or refine the minimum reusable shared surfaces needed across pages
+    - examples: note-like cards, taped section treatments, shared page header patterns, stable spacing and typography rules
+- How to work with this phase:
+  - ask for a baseline audit first
+  - then ask for the minimum shared UI surface extraction needed before page redesign
+  - keep this branch focused on shared design foundations rather than rebuilding landing or dashboard inside the same branch
+- Verification before moving on:
+  - shared UI review
+  - token compliance
+  - responsive baseline
+  - design-review pass showing the refreshed direction is clear enough for page-level work
+
+#### Phase 3 - Surface Refresh
+
+- Recommended branch split:
+  - `ui/<n>--refresh-landing-page`
+  - `ui/<n>--refresh-dashboard-page`
+- Responsibility:
+  - rebuild the two existing visible surfaces on top of the refreshed design foundation
+  - landing should define the public-facing tone
+  - dashboard should translate that tone into the authenticated app surface
+- Dependency:
+  - Phase 2
+- Verification before moving on:
+  - landing responsive checks and accessibility review
+  - dashboard empty/loading-state review and app-surface consistency check
+  - visual alignment between landing and dashboard after both branches are complete
+  - preferred execution order: landing first, then dashboard
+  - parallel execution is possible only if the shared design foundation is already stable enough that both branches can follow the same visual rules without divergence
+
+#### Phase 4 - Account Foundation
+
+- Recommended branch split:
+  - `feature/<n>--auth-entry-flow`
+    - sign up, log in, auth UI, and session entry behavior
+  - `feature/<n>--app-shell-route-guard`
+    - protected routes, authenticated shell, and navigation framing
+  - `feature/<n>--profile-page`
+    - minimal account/profile surface for MVP
+    - example scope: account info, display name, logout entry, and profile-level navigation anchor
+- Dependency:
+  - Phase 3
+- Verification before moving on:
+  - login/logout smoke flow
+  - protected-route behavior
+  - app-shell navigation checks
+  - profile page basic account-flow coverage
+
+#### Phase 5 - Board Foundation
+
+- Recommended branch split:
+  - `feature/<n>--board-domain-foundation`
+    - server-side board, cell, task, and event foundations
+    - minimum persisted board creation flow
+    - route-level board detail shell that can load and render a created board
+  - `feature/<n>--boards-page`
+    - user-owned board list or "My Boards" surface
+    - navigation between boards list, board creation entry, and board detail shell
+- Notes:
+  - the boards list page is part of MVP and should not be treated as optional
+  - this phase should stop at create/list/detail shell behavior and should not absorb the full editing interaction model
+- Dependency:
+  - Phase 4
+- Verification before moving on:
+  - data-boundary verification
+  - schema or contract checks
+  - minimal integration coverage for board create/list/detail-shell flows
+
+#### Phase 6 - Board Editing
+
+- Recommended branch split:
+  - `feature/<n>--board-view-surface`
+    - the default board screen with its non-focused overview state
+  - `feature/<n>--cell-detail-flow`
+    - focused cell detail, task editing, and completion changes
+  - `feature/<n>--board-save-flow`
+    - autosave, failure handling, and any conflict/version behavior required by the MVP spec
+- Notes:
+  - the non-focused board state should already be the normal board view
+  - MVP does not require a separate read-only page or mode by default
+  - export preview or sharing-oriented presentation views can remain later concerns unless a branch proves they are necessary for MVP
+- Dependency:
+  - Phase 5
+- Verification before moving on:
+  - core board smoke flow
+  - failure-path handling
+  - mutation consistency checks
+
+#### Phase 7 - Dashboard Data Integration
+
+- Recommended branch split:
+  - `feature/<n>--dashboard-data-integration`
+- Responsibility:
+  - replace placeholder dashboard values with real progress, activity, and board data derived from the board workflow
+- Dependency:
+  - Phase 6
+- Verification before moving on:
+  - data-integrity checks for summary metrics
+  - chart correctness
+  - recent activity accuracy
+  - board-list accuracy where dashboard links or summaries depend on real board state
+
+#### Phase 8 - Export and Templates
+
+- Recommended branch split:
+  - `feature/<n>--board-export`
+  - `feature/<n>--template-entry-flow`
+- Dependency:
+  - Phases 6-7
+- Verification before moving on:
+  - export quality checks
+  - template creation flow checks
+  - regression checks on board creation
+
+#### Phase 9 - MVP Hardening
+
+- Recommended branch split:
+  - `chore/<n>--mvp-hardening-and-e2e`
+- Responsibility:
+  - close resilience gaps, add smoke coverage for critical journeys, and confirm the MVP is release-ready
+- Dependency:
+  - Phases 4-8
+- Verification before moving on:
+  - E2E smoke pass
+  - failure-path review
+  - doc sync
+  - final verification evidence
+
+### 8.4 Dependency Rules
+
+- Do not start deep feature branches before the design foundation and the two visible baseline surfaces are refreshed.
+- Do not wire real dashboard data before the board domain and board editor flows exist.
+- Do not treat export or templates as first-wave work; they depend on the board model and core editing loop being stable first.
+- If a future branch needs to break this order, update the branch-local spec and the master plan rather than silently drifting from the roadmap.
 
 ---
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -1,6 +1,6 @@
 # Mandalart Web - MASTER PLAN (v0.1)
 
-_Last updated: 2026-03-15 (KST)_
+_Last updated: 2026-03-17 (KST)_
 
 ---
 
@@ -386,10 +386,68 @@ The roadmap should optimize for two things at once:
 
 ## 9) Verification and Documentation Sync
 
-This section will define how document verification, branch verification, and English/Korean sync should happen as the roadmap advances.
+Verification should stay proportional to the branch type, but every phase should leave behind enough evidence that the next branch does not need to guess whether the baseline is trustworthy.
+
+### 9.1 Branch Verification Expectations
+
+- **Docs branches**
+  - verify document structure, paths, terminology, and cross-document ownership
+  - run formatting and diff-safety checks before completion
+- **UI branches**
+  - verify responsive behavior, accessibility basics, semantic-token compliance, and alignment with the approved design foundation
+- **Feature branches**
+  - verify happy path, at least one failure path, and data-boundary correctness
+  - add smoke or integration evidence for the new user-facing flow before the next phase depends on it
+- **Hardening branches**
+  - verify cross-flow regressions, release-readiness evidence, and the final MVP path set
+
+### 9.2 Documentation Sync Order
+
+- Finalize the English source document first.
+- Sync Korean documents only after the English source is accepted for the current branch.
+- When a roadmap change affects other project documents, update:
+  1. the owning English source document
+  2. the corresponding Korean document
+  3. the current branch handoff and verification notes when needed
+
+### 9.3 Branch-Cycle Evidence
+
+- Each non-trivial branch should leave behind:
+  - `spec.md`
+  - `research.md` when required
+  - `plan.md`
+  - `log.md`
+  - `handoff.md`
+- Future branches should treat those artifacts as execution evidence, not optional notes.
 
 ---
 
 ## 10) Risks and Decision Checkpoints
 
-This section will capture the main delivery risks, scope boundaries, and the decision points that should trigger a replan instead of ad-hoc drift.
+The roadmap should be updated intentionally when reality changes. The goal is not to freeze the project forever, but to prevent silent drift.
+
+### 10.1 Main Risks
+
+- **Design drift**
+  - landing, dashboard, and board surfaces can diverge if the shared design foundation is weak
+- **Oversized branches**
+  - roadmap phases can still become too large if multiple concerns are bundled into one branch
+- **Premature feature wiring**
+  - wiring dashboard metrics, export, or template flows too early can force rework before the board model and editing loop are stable
+- **Document duplication**
+  - `MASTER-PLAN`, `PRD`, `SCAFFOLD_STRUCTURE`, and `TECH_REFERENCE` can become redundant if section ownership is not enforced
+
+### 10.2 Replan Triggers
+
+Stop and replan instead of patching around the issue when:
+
+- a branch needs to cross the accepted phase order in a meaningful way
+- a branch grows beyond a single clear responsibility
+- the UI refresh requires changing the token contract or core visual identity
+- the board domain or editing model changes in a way that invalidates downstream roadmap assumptions
+- MVP suddenly requires a separate read-only board mode, sharing mode, or other new surface not accounted for here
+
+### 10.3 Decision Rule
+
+- If the change affects only one branch's local implementation details, update the branch-local plan.
+- If the change affects multiple future branches, update this master plan first, then continue execution from the corrected roadmap.

--- a/docs/ko/MASTER-PLAN.md
+++ b/docs/ko/MASTER-PLAN.md
@@ -1,0 +1,453 @@
+# Mandalart Web - MASTER PLAN (v0.1)
+
+_Last updated: 2026-03-17 (KST)_
+
+---
+
+## 1) 목적
+
+이 문서는 Mandalart Web의 최상위 전달 계획 문서다.
+현재 소스 오브 트루스 문서들을 연결하고, 활성 프로젝트 baseline을 고정하며, 앞으로의 이슈 기반 브랜치가 현재 상태에서 MVP 완료까지 어떤 순서로 진행되어야 하는지 정의하기 위해 존재한다.
+
+이 문서는 핵심 문서를 대체하지 않는다.
+
+- `docs/PRD.md`는 제품 목표, 범위, 기능 요구사항을 계속 소유한다.
+- `docs/SCAFFOLD_STRUCTURE.md`는 스캐폴드, 레이어, 파일 배치 규칙을 계속 소유한다.
+- `docs/TECH_REFERENCE.md`는 기술 구현 세부사항을 계속 소유한다.
+- `AGENTS.md`는 항상 적용되는 프로젝트 및 워크플로 규칙을 계속 소유한다.
+
+이 마스터 플랜은 그 위 계층의 내용을 소유한다.
+
+- 현재 전달 baseline
+- 협상 불가능한 프로젝트 제약
+- 앞으로의 브랜치를 어떤 순서로 실행해야 하는지
+- 브랜치 작업이 프로젝트 아이덴티티와 아키텍처에 맞게 유지되도록 하는 체크포인트
+
+---
+
+## 2) 소스 오브 트루스 맵
+
+향후 브랜치를 계획하거나 실행할 때는 아래 순서로 프로젝트 문서를 사용한다.
+
+1. `docs/MASTER-PLAN.md`
+   - 전달 baseline
+   - 브랜치 로드맵
+   - 문서 간 사용 순서
+   - 프로젝트 수준 의사결정 체크포인트
+2. `docs/PRD.md`
+   - 제품 목표
+   - MVP 범위
+   - 사용자-facing 요구사항
+3. `docs/SCAFFOLD_STRUCTURE.md`
+   - 앱 구조
+   - 레이어 경계
+   - UI 표면 소유권
+4. `docs/TECH_REFERENCE.md`
+   - 툴체인
+   - 스키마 및 데이터 세부사항
+   - 기술 구현 규약
+5. `AGENTS.md`
+   - 프로젝트 전역 AI 규칙
+   - 브랜치 사이클 워크플로
+   - 문서 동기화 기대사항
+
+`.agent/sessions/[#<issue-number>]<prefix>--<slug>/` 아래의 브랜치 로컬 아티팩트는 각 브랜치의 실행 기록으로 유지되며, 로컬 의도는 이 마스터 플랜과 위의 소유 문서들을 기준으로 파생되어야 한다.
+
+---
+
+## 3) 현재 Baseline
+
+이 저장소는 이제 greenfield scaffold가 아니라 활성 baseline으로 다뤄야 한다.
+
+### 3.1 전달 Baseline
+
+- 프로젝트 셋업과 툴체인 기반은 이미 갖춰져 있다.
+- 공유 색상 및 테마 토큰 기반 작업이 이미 반영되어 있다.
+- 공유 shadcn/ui 기반이 이미 설치되어 사용 중이다.
+- 브랜치 사이클 프로젝트 문서는 이전 docs 브랜치에서 정렬되었다.
+
+### 3.2 제품 및 UI Baseline
+
+- 서비스 아이덴티티는 애플리케이션 메타데이터와 현재 UI에 이미 반영되어 있다.
+- 랜딩 페이지는 이미 구현되어 있다.
+- 대시보드 페이지는 이미 구현되어 있다.
+- 제품 방향은 generic productivity tool이 아니라 Mandalart 계획 방식에 맞춰져 있다.
+
+### 3.3 시각 Baseline
+
+- `src/app/globals.css`가 이미 semantic color token 계약을 정의하고 있다.
+- 현재 UI는 이미 warm paper 스타일 팔레트, 카드 표면, 메모 같은 포인트를 사용하고 있다.
+- 기존 컴포넌트는 tape, pinned-card composition, planning-board 언어 같은 note-board 단서를 이미 사용하고 있다.
+
+### 3.4 워크플로 Baseline
+
+- 각 브랜치는 하나의 이슈에 대응한다.
+- 각 브랜치는 각자의 스레드에서 작업한다.
+- 비사소한 작업은 `.agent/sessions/...` 아래의 브랜치 사이클을 따른다.
+
+이 baseline이 중요한 이유는, 후속 브랜치가 아무것도 구현되지 않은 상태를 가정하는 것이 아니라 지금 존재하는 것을 정제하고 확장해야 하기 때문이다.
+
+---
+
+## 4) 고정 제약
+
+이 제약들은 프로젝트 수준의 결정이며, 이후 브랜치에서 문서화된 정당화와 함께 명시적으로 변경하지 않는 한 참으로 가정해야 한다.
+
+### 4.1 아이덴티티 제약
+
+- 서비스명과 현재 제품 아이덴티티를 유지한다.
+- Mandalart를 목표 계획과 보드 기반 실행의 핵심 프레이밍으로 유지한다.
+- 제품을 generic dashboard나 generic note-taking app으로 재포지셔닝하지 않는다.
+
+### 4.2 시각 시스템 제약
+
+- 현재 색상 방향을 기본 시각 방향으로 유지한다.
+- `src/app/globals.css`의 semantic token 시스템을 공유 스타일 계약으로 유지한다.
+- 메모/종이/노트 작성 컨셉을 제품 시각 아이덴티티의 일부로 유지한다.
+- 이후 UI refresh 작업은 레이아웃, 타이포그래피, 간격, 모션, 구성은 재해석할 수 있지만, token 기반 아이덴티티 시스템을 버리면 안 된다.
+
+### 4.3 아키텍처 제약
+
+- 현재의 App Router + TypeScript + Prisma + Supabase 아키텍처 방향을 유지한다.
+- 데이터베이스 접근은 server-side only로 유지한다.
+- Prisma를 애플리케이션의 주요 데이터 접근 계층으로 유지한다.
+- Supabase는 auth/session, storage, RLS enforcement를 담당하도록 유지한다.
+- 스캐폴드는 `docs/SCAFFOLD_STRUCTURE.md`에 정의된 FSD-lite 구조에 맞춰 유지한다.
+
+### 4.4 워크플로 제약
+
+- 브랜치당 하나의 이슈, 하나의 스레드 규칙을 유지한다.
+- 비사소한 작업은 브랜치 사이클을 유지한다.
+- `docs/*.md` 아래의 영문 문서를 소스 오브 트루스로 유지한다.
+- 한국어 문서는 영문 소스가 확정된 뒤에만 동기화한다.
+
+---
+
+## 5) 이 마스터 플랜이 명확히 해야 할 것
+
+이 문서는 향후 브랜치가 아래 프로젝트 수준 질문에 대해 일관된 답을 얻도록 해야 한다.
+
+- 무엇이 이미 구현되어 있고 활성 baseline으로 다뤄져야 하는가?
+- 현재 아이덴티티 중 무엇이 고정이고 무엇이 재설계 가능한가?
+- 지금 시점부터 제품, UI, 기능 작업을 어떤 순서로 진행해야 하는가?
+- 어떤 종류의 결정이 어떤 소유 문서에 속하는가?
+- 프로젝트가 브랜치 단위로 진행될 때 어떤 검증 및 문서 동기화 기대사항이 적용되는가?
+
+이후 섹션은 이미 다른 문서가 소유하는 상세 제품/기술 명세를 중복하지 않으면서, 위 질문들을 실행 가능한 로드맵으로 전환한다.
+
+---
+
+## 6) 제품 및 경험 방향
+
+마스터 플랜은 작업 순서를 정하는 데 필요한 수준의 제품 및 경험 방향만 정의해야 한다.
+상세 요구사항, 필드 규칙, 사용자-facing acceptance는 계속 `docs/PRD.md`에 속한다.
+
+### 6.1 제품 방향
+
+- `docs/PRD.md`에 이미 정의된 MVP 흐름을 우선한다.
+  - 계정 기반 접근
+  - 보드 생성 및 관리
+  - 태스크 완료 흐름
+  - 대시보드 가시성
+  - 내보내기 출력
+- 현재 랜딩과 대시보드 구현을 버릴 실험이 아니라 정제할 baseline 표면으로 취급한다.
+- 로드맵은 정적이거나 데모 중심의 UI 표면에서 실제 MVP 동작으로 통제된 순서로 이동해야 한다.
+
+### 6.2 UX 방향
+
+- 랜딩, 대시보드, 향후 보드 관련 표면 전반에서 메모/종이/planning-board 컨셉을 유지한다.
+- 제품은 우선 읽기 쉽고 구조적이어야 하며, 시각 refresh는 장식적 복잡성보다 명확성, 위계, 계획 흐름을 강화해야 한다.
+- 보드 흐름을 핵심 경험으로 두고, 대시보드는 주요 편집 표면이 아니라 요약 및 진행률 표면으로 유지한다.
+- 랜딩과 대시보드 refresh는 서비스 아이덴티티가 하나의 시스템처럼 읽히도록 시각적으로 정렬되어야 한다.
+- 기본 보드 화면은 overview 상태이면서 동시에 편집 진입점으로 취급한다.
+  - 비집중 상태의 보드가 곧 normal board view여야 한다.
+  - 셀 선택 시 drawer나 side panel 같은 focused edit surface로 전환되어야 한다.
+  - 별도 read-only board mode는 이후 브랜치에서 구체적인 sharing 또는 presentation 요구가 생기지 않는 한 MVP에 필요하지 않다.
+
+---
+
+## 7) 아키텍처 및 전달 원칙
+
+마스터 플랜은 로드맵 순서에 실질적으로 영향을 주는 아키텍처 및 전달 규칙만 다시 적어야 한다.
+상세 파일 배치 및 기술 구현 규칙은 계속 `docs/SCAFFOLD_STRUCTURE.md`, `docs/TECH_REFERENCE.md`, `AGENTS.md`에 속한다.
+
+### 7.1 아키텍처 원칙
+
+- 데이터베이스 접근은 server-side only로 유지하고, Prisma를 주요 데이터 접근 계층으로, Supabase를 auth, storage, RLS 담당으로 유지한다.
+- App Router scaffold, layer boundary, UI surface separation은 `docs/SCAFFOLD_STRUCTURE.md`에 정의된 방향을 유지한다.
+- 새 프로젝트 UI primitive나 로컬 색상 결정을 도입하기 전에 설치된 `shadcn/ui`, 기존 shared UI, semantic token을 우선 재사용한다.
+- 새 작업은 import와 boundary만 봐도 설명 가능해야 하며, 저가치 repository, adapter, wrapper layer는 피한다.
+
+### 7.2 브랜치 전달
+
+- 브랜치당 하나의 이슈, 하나의 스레드 규칙을 유지한다.
+- 비사소한 작업은 문서화된 브랜치 사이클과 `.agent/sessions/...` 아래 브랜치 로컬 아티팩트를 사용한다.
+- UI refresh 작업은 깊은 feature 브랜치 안에 숨기지 말고 dedicated UI 브랜치로 유지한다.
+- 로드맵이나 아키텍처 가이드가 변경될 때는 영문 소스 문서를 먼저 업데이트하고, 그 뒤 한국어 문서를 동기화한다.
+
+---
+
+## 8) 브랜치 로드맵
+
+로드맵은 아래 두 가지를 동시에 최적화해야 한다.
+
+- UI가 refresh되는 동안 현재 서비스 아이덴티티를 보존하는 것
+- 시각 시스템과 앱/데이터 기초가 안정되기 전에 기능 구현 범위를 무리하게 넓히지 않는 것
+
+### 8.1 시퀀싱 로직
+
+- 최상위 계획 문서를 먼저 완료해서 이후 브랜치가 하나의 baseline과 하나의 source-of-truth map을 상속받게 한다.
+- 더 많은 화면이나 기능 흐름을 확장하기 전에 shared design foundation을 먼저 refresh한다.
+- 랜딩과 대시보드는 이미 존재하고 서비스의 가시적 아이덴티티를 결정하므로 이른 시점에 refresh한다.
+- 유저 소유 보드 흐름을 확장하기 전에 auth와 application shell 동작을 정립한다.
+- 실제 대시보드 지표와 export output을 연결하기 전에 보드 도메인과 편집 워크플로를 먼저 정립한다.
+- 주요 MVP 루프가 들어온 뒤에 hardening 및 release-readiness 작업으로 마무리한다.
+
+### 8.2 Phase 모델
+
+- phase는 delivery milestone이지, 반드시 한 브랜치로 끝나야 하는 경계가 아니다.
+- 대부분의 phase는 각각 하나의 주요 책임을 가진 `1-3`개의 작은 브랜치로 실행하는 것이 좋다.
+- 하나의 브랜치가 아래를 동시에 먹게 되면 phase를 여러 브랜치로 분리한다.
+  - shared UI foundation 작업과 page redesign
+  - auth/session 작업과 unrelated account surface
+  - domain modeling과 여러 페이지, interaction-heavy editing
+- 아래 로드맵은 먼저 권장 phase 범위를 적고, 그 다음 가능한 브랜치 분해를 적는다.
+
+### 8.3 Phase 상세
+
+#### Phase 0 - 완료된 Baseline
+
+- 완료된 브랜치:
+  - `feat/1--color`
+  - `ui/3--shadcn-components`
+  - `ui/5--landing-page`
+  - `ui/7--dashboard-page`
+  - `docs/9--update-agentic-docs`
+- 책임:
+  - token foundation, shared UI primitive, 초기 landing/dashboard surface, 정렬된 프로젝트 문서를 확보한다.
+- 다음으로 넘어가기 전 검증:
+  - 현재 저장소 상태를 향후 계획의 고정 baseline으로 취급한다.
+
+#### Phase 1 - 현재 계획 브랜치
+
+- 현재 브랜치:
+  - `docs/11--define-project-master-plan`
+- 책임:
+  - 마스터 플랜을 완성하고, 전달 순서를 고정하며, source-of-truth ownership을 명시적으로 유지한다.
+- 다음으로 넘어가기 전 검증:
+  - 승인된 `docs/MASTER-PLAN.md`
+  - 검증된 session artifact
+  - 최종 문서 정렬
+
+#### Phase 2 - Design Foundation Refresh
+
+- 이 phase가 필요한 이유:
+  - 랜딩과 대시보드는 이미 존재하지만, 더 많은 기능 표면을 추가하기 전에 refreshed UI 방향을 먼저 통일해야 한다.
+- 권장 브랜치:
+  - `ui/<n>--refresh-design-foundation`
+    - 현재 시각 언어를 audit한다.
+    - refreshed note/paper 방향을 고정한다.
+    - 페이지 전반에서 사용할 최소 shared surface를 구현하거나 정리한다.
+    - 예시: note-like card, taped section treatment, shared page header pattern, 안정적인 spacing/typography rule
+- 이 phase를 작업하는 방법:
+  - 먼저 baseline audit를 요청한다.
+  - 그 다음 page redesign 전에 필요한 최소 shared UI surface 추출을 요청한다.
+  - 같은 브랜치 안에서 landing이나 dashboard를 재구축하지 말고 shared design foundation에만 집중한다.
+- 다음으로 넘어가기 전 검증:
+  - shared UI review
+  - token compliance
+  - responsive baseline
+  - page-level 작업을 시작하기에 충분히 방향이 명확한지에 대한 design-review pass
+
+#### Phase 3 - Surface Refresh
+
+- 권장 브랜치 분할:
+  - `ui/<n>--refresh-landing-page`
+  - `ui/<n>--refresh-dashboard-page`
+- 책임:
+  - refreshed design foundation 위에서 이미 존재하는 두 visible surface를 재구성한다.
+  - landing은 public-facing tone을 정의해야 한다.
+  - dashboard는 그 tone을 authenticated app surface로 번역해야 한다.
+- 의존성:
+  - Phase 2
+- 다음으로 넘어가기 전 검증:
+  - landing responsive check 및 accessibility review
+  - dashboard empty/loading-state review 및 app-surface consistency check
+  - 두 브랜치 완료 후 landing과 dashboard 간 visual alignment 확인
+  - 권장 실행 순서: landing 먼저, 그다음 dashboard
+  - 병렬 실행은 shared design foundation이 충분히 안정되어 두 브랜치가 같은 시각 규칙을 따를 수 있을 때만 허용한다.
+
+#### Phase 4 - Account Foundation
+
+- 권장 브랜치 분할:
+  - `feature/<n>--auth-entry-flow`
+    - 회원가입, 로그인, auth UI, 세션 진입 동작
+  - `feature/<n>--app-shell-route-guard`
+    - protected route, authenticated shell, navigation framing
+  - `feature/<n>--profile-page`
+    - MVP용 최소 account/profile 표면
+    - 예시 범위: account info, display name, logout entry, profile-level navigation anchor
+- 의존성:
+  - Phase 3
+- 다음으로 넘어가기 전 검증:
+  - login/logout smoke flow
+  - protected-route 동작
+  - app-shell navigation check
+  - profile page 기본 account-flow coverage
+
+#### Phase 5 - Board Foundation
+
+- 권장 브랜치 분할:
+  - `feature/<n>--board-domain-foundation`
+    - server-side board, cell, task, event 기반
+    - 최소 persisted board creation flow
+    - 생성된 보드를 불러와 렌더링할 수 있는 route-level board detail shell
+  - `feature/<n>--boards-page`
+    - 유저 소유 board list 또는 "My Boards" 표면
+    - boards list, board creation entry, board detail shell 간 navigation
+- 참고:
+  - boards list page는 MVP 범위이며 optional로 다루면 안 된다.
+  - 이 phase는 create/list/detail shell 동작까지만 다뤄야 하며, 전체 editing interaction model까지 흡수하면 안 된다.
+- 의존성:
+  - Phase 4
+- 다음으로 넘어가기 전 검증:
+  - data-boundary verification
+  - schema 또는 contract check
+  - board create/list/detail-shell flow에 대한 최소 integration coverage
+
+#### Phase 6 - Board Editing
+
+- 권장 브랜치 분할:
+  - `feature/<n>--board-view-surface`
+    - 비집중 overview state를 가진 기본 board screen
+  - `feature/<n>--cell-detail-flow`
+    - focused cell detail, task editing, completion change
+  - `feature/<n>--board-save-flow`
+    - autosave, failure handling, MVP 명세에 필요한 conflict/version 동작
+- 참고:
+  - 비집중 보드 상태가 곧 normal board view여야 한다.
+  - 별도 read-only page 또는 mode는 기본 MVP 요구사항이 아니다.
+  - export preview나 sharing-oriented presentation view는 이후 브랜치에서 정말 필요성이 입증될 때까지 뒤로 미룬다.
+- 의존성:
+  - Phase 5
+- 다음으로 넘어가기 전 검증:
+  - core board smoke flow
+  - failure-path handling
+  - mutation consistency check
+
+#### Phase 7 - Dashboard Data Integration
+
+- 권장 브랜치 분할:
+  - `feature/<n>--dashboard-data-integration`
+- 책임:
+  - placeholder dashboard 값을 board workflow에서 파생된 실제 progress, activity, board data로 교체한다.
+- 의존성:
+  - Phase 6
+- 다음으로 넘어가기 전 검증:
+  - summary metric의 data-integrity check
+  - chart correctness
+  - recent activity accuracy
+  - dashboard 링크나 summary가 실제 board state에 의존할 때의 board-list accuracy
+
+#### Phase 8 - Export and Templates
+
+- 권장 브랜치 분할:
+  - `feature/<n>--board-export`
+  - `feature/<n>--template-entry-flow`
+- 의존성:
+  - Phases 6-7
+- 다음으로 넘어가기 전 검증:
+  - export quality check
+  - template creation flow check
+  - board creation regression check
+
+#### Phase 9 - MVP Hardening
+
+- 권장 브랜치 분할:
+  - `chore/<n>--mvp-hardening-and-e2e`
+- 책임:
+  - resilience gap을 닫고, critical journey smoke coverage를 추가하며, MVP가 release-ready인지 확인한다.
+- 의존성:
+  - Phases 4-8
+- 다음으로 넘어가기 전 검증:
+  - E2E smoke pass
+  - failure-path review
+  - 문서 동기화
+  - final verification evidence
+
+### 8.4 Dependency 규칙
+
+- design foundation과 두 visible baseline surface가 refresh되기 전에는 깊은 feature 브랜치를 시작하지 않는다.
+- board domain과 board editor flow가 존재하기 전에는 실제 dashboard data를 연결하지 않는다.
+- export나 template을 first-wave 작업으로 취급하지 않는다. 둘 다 먼저 안정된 board model과 core editing loop에 의존한다.
+- 향후 브랜치가 이 순서를 의미 있게 깨야 한다면, 조용히 drift하지 말고 branch-local spec과 master plan을 먼저 업데이트한다.
+
+---
+
+## 9) 검증 및 문서 동기화
+
+검증은 브랜치 유형에 비례해야 하지만, 모든 phase는 다음 브랜치가 baseline을 신뢰할 수 있을 만큼의 근거를 남겨야 한다.
+
+### 9.1 브랜치 검증 기대사항
+
+- **문서 브랜치**
+  - 문서 구조, 경로, 용어, 문서 간 ownership을 검증한다.
+  - 완료 전에 formatting 및 diff-safety check를 실행한다.
+- **UI 브랜치**
+  - responsive 동작, 기본 접근성, semantic-token compliance, 승인된 design foundation 정렬 여부를 검증한다.
+- **기능 브랜치**
+  - happy path, 최소 하나의 failure path, data-boundary correctness를 검증한다.
+  - 다음 phase가 의존하기 전에 새 사용자 흐름에 대한 smoke 또는 integration 근거를 남긴다.
+- **Hardening 브랜치**
+  - cross-flow regression, release-readiness evidence, 최종 MVP 주요 경로를 검증한다.
+
+### 9.2 문서 동기화 순서
+
+- 영문 소스 문서를 먼저 확정한다.
+- 한국어 문서는 현재 브랜치에서 영문 소스가 승인된 뒤에만 동기화한다.
+- 로드맵 변경이 다른 프로젝트 문서에 영향을 줄 때는 아래 순서로 업데이트한다.
+  1. 소유 영문 소스 문서
+  2. 대응하는 한국어 문서
+  3. 필요하다면 현재 브랜치의 handoff 및 verification note
+
+### 9.3 브랜치 사이클 근거
+
+- 각 비사소한 브랜치는 아래 아티팩트를 남겨야 한다.
+  - `spec.md`
+  - 필요한 경우 `research.md`
+  - `plan.md`
+  - `log.md`
+  - `handoff.md`
+- 향후 브랜치는 이 아티팩트를 optional note가 아니라 execution evidence로 취급해야 한다.
+
+---
+
+## 10) 리스크 및 의사결정 체크포인트
+
+로드맵은 현실이 바뀔 때 의도적으로 업데이트되어야 한다. 목표는 프로젝트를 영원히 고정하는 것이 아니라, 조용한 drift를 막는 것이다.
+
+### 10.1 주요 리스크
+
+- **디자인 drift**
+  - shared design foundation이 약하면 landing, dashboard, board surface가 서로 다른 방향으로 갈 수 있다.
+- **과도하게 큰 브랜치**
+  - 로드맵 phase를 나눠도 여러 관심사를 한 브랜치에 묶으면 다시 비대해질 수 있다.
+- **너무 이른 기능 연결**
+  - dashboard metric, export, template 흐름을 너무 일찍 연결하면 board model과 editing loop가 안정되기 전에 재작업이 생길 수 있다.
+- **문서 중복**
+  - section ownership을 지키지 않으면 `MASTER-PLAN`, `PRD`, `SCAFFOLD_STRUCTURE`, `TECH_REFERENCE`가 중복될 수 있다.
+
+### 10.2 리플랜 트리거
+
+아래 상황에서는 patch로 때우지 말고 멈춰서 리플랜한다.
+
+- 브랜치가 승인된 phase 순서를 의미 있게 가로질러야 할 때
+- 브랜치가 하나의 명확한 책임 범위를 넘어설 때
+- UI refresh가 token contract 또는 core visual identity 변경을 요구할 때
+- board domain 또는 editing model이 downstream roadmap 가정을 깨는 방향으로 바뀔 때
+- MVP에 별도 read-only board mode, sharing mode, 혹은 여기에 없는 새 surface가 갑자기 필요해질 때
+
+### 10.3 의사결정 규칙
+
+- 변경이 하나의 브랜치 내부 구현 세부사항에만 영향을 주면 branch-local plan을 업데이트한다.
+- 변경이 여러 미래 브랜치에 영향을 주면, 먼저 이 master plan을 업데이트한 뒤 수정된 roadmap 기준으로 실행을 이어간다.


### PR DESCRIPTION
## Linked Issue

Closes #11

## Content

This PR adds the project-level master plan for Mandalart Web and aligns it with the current branch-cycle workflow and repository baseline.

Changes included in this PR:
- added `docs/MASTER-PLAN.md` as the canonical top-level delivery plan
- added `docs/ko/MASTER-PLAN.md` after finalizing the English source
- documented the current implementation baseline, fixed constraints, verification rules, and roadmap ownership
- defined the roadmap phases from design foundation refresh through MVP hardening
- clarified that roadmap phases are milestone groupings rather than mandatory one-branch units
- refined roadmap branch naming to keep branch intent more single-purpose and easier to scan
- recorded branch-cycle execution artifacts for this docs branch under `.agent/sessions/[#11]docs--define-project-master-plan/`

## Images

N/A for this docs-only PR.

## Misc

- The roadmap is the primary output of this PR; the surrounding sections were intentionally kept concise to avoid duplicating `PRD`, `SCAFFOLD_STRUCTURE`, and `TECH_REFERENCE`.
- Korean translation was added only after the English source was finalized.
- `pnpm run lint` still fails because of existing repository-wide Biome/config and formatting issues in unrelated files, including `biome.json`, `src/app/globals.css`, `src/shared/lib/utils.ts`, `tests/e2e/example.spec.ts`, `playwright.config.ts`, and `src/shared/ui/ComponentExample.tsx`.
- Unrelated local changes in `.github/workflows/playwright.yml` and `pnpm-lock.yaml` were left untouched and are not part of this PR.

## Checklist

- [x] Linked issue is correct
- [x] Changes match the issue goal and tasks
- [x] Tests added or updated (if applicable)
- [x] No unintended changes included
