### PR TITLE
mistaken merge

### DIFF
--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Branch implementation, hardening, review, and final verification are complete.
+- Status: Post-review grid-visibility fix applied and ready to commit.
 
 ## Completed
 
@@ -75,6 +75,9 @@
     - final lint/diff verification passed
     - desktop and mobile-width visual spot-checks passed on landing and dashboard
 21. Committed the hardening/refactor follow-up as `d7a01a9` (`♻️ refactor: tighten note section motion transitions`).
+22. Applied a post-review shared-foundation fix for `GridPatternBackground` visibility:
+    - removed the double attenuation between `--note-grid` and the component-level `tone` opacity
+    - kept the fix in `src/app/globals.css` so all current call sites inherit the corrected grid visibility
 
 ## Decisions
 
@@ -109,7 +112,8 @@
 
 ## Pending
 
-1. Prepare the branch closeout summary.
+1. Commit the grid-visibility follow-up.
+2. Prepare the branch closeout summary.
 
 ## Risks / Notes
 
@@ -146,7 +150,10 @@
 - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
 - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'` -> pass
 - Playwright mobile-width spot-check -> pass (`http://127.0.0.1:3000/`, `http://127.0.0.1:3000/dashboard`)
+- `pnpm exec biome check src/app/globals.css src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- `pnpm exec eslint src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- `git diff --check -- src/app/globals.css src/shared/ui/common/GridPatternBackground.tsx` -> pass
 
 ## Resume
 
-- Next prompt: "Summarize branch closeout for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Commit the grid-visibility follow-up and summarize closeout for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Slice 1 complete and ready to commit. Slice 2 is next.
+- Status: Slice 2 complete and ready to commit. Slice 3 is next and requires a user checkpoint before commit.
 
 ## Completed
 
@@ -50,6 +50,12 @@
     - added note-material semantic support roles in `src/app/globals.css`
     - refined `DecoTape` into a configurable shared accent helper
     - refined `GridPatternBackground` so tone/density are token-backed and reusable
+12. Committed Slice 1 as `05527ae` (`🎨 style: refine note material tokens and accents`).
+13. Committed the project workflow guidance update as `f692fff` (`📝 docs: tighten UI branch design workflow guidance`).
+14. Executed Slice 2:
+    - added `src/shared/ui/common/NoteSurface.tsx`
+    - implemented the note surface as a low-level wrapper over the existing shadcn `Card`
+    - kept the shared API limited to material concerns (`tone`, `depth`) so page composition still stays local
 
 ## Decisions
 
@@ -84,10 +90,9 @@
 
 ## Pending
 
-1. Commit Slice 1 from `plan.md`.
-2. Execute Slice 2 from `plan.md`.
-3. Execute Slice 3 and stop at the required user checkpoint after the landing-facing validation slice.
-4. Execute Slice 4 after the landing validation is accepted.
+1. Commit Slice 2 from `plan.md`.
+2. Execute Slice 3 and stop at the required user checkpoint after the landing-facing validation slice.
+3. Execute Slice 4 after the landing validation is accepted.
 
 ## Risks / Notes
 
@@ -110,7 +115,10 @@
 - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
 - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
 - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx` -> pass
+- `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx` -> pass
+- `git diff --check -- src/shared/ui/common/NoteSurface.tsx` -> pass
 
 ## Resume
 
-- Next prompt: "Commit Slice 1 and execute Slice 2 from `plan.md` for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Commit Slice 2 and execute Slice 3 from `plan.md` for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Branch implementation complete. Final hardening/review passed; one small hardening/refactor commit is pending.
+- Status: Branch implementation, hardening, review, and final verification are complete.
 
 ## Completed
 
@@ -74,6 +74,7 @@
     - no blocking findings remained under `web-design-guidelines`
     - final lint/diff verification passed
     - desktop and mobile-width visual spot-checks passed on landing and dashboard
+21. Committed the hardening/refactor follow-up as `d7a01a9` (`♻️ refactor: tighten note section motion transitions`).
 
 ## Decisions
 
@@ -108,8 +109,7 @@
 
 ## Pending
 
-1. Commit the final hardening/refactor follow-up.
-2. Prepare the branch closeout summary.
+1. Prepare the branch closeout summary.
 
 ## Risks / Notes
 
@@ -149,4 +149,4 @@
 
 ## Resume
 
-- Next prompt: "Commit the hardening/refactor follow-up and summarize branch closeout for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Summarize branch closeout for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Slice 2 complete and ready to commit. Slice 3 is next and requires a user checkpoint before commit.
+- Status: Slice 3 implemented and verified. Waiting at the required user checkpoint before commit.
 
 ## Completed
 
@@ -56,6 +56,11 @@
     - added `src/shared/ui/common/NoteSurface.tsx`
     - implemented the note surface as a low-level wrapper over the existing shadcn `Card`
     - kept the shared API limited to material concerns (`tone`, `depth`) so page composition still stays local
+15. Committed Slice 2 as `35ff6a4` (`✨ feat: add shared note surface primitive`).
+16. Executed Slice 3 for landing validation:
+    - applied `NoteSurface` to the representative paper wrappers in `MethodSection` and `CtaSection`
+    - switched those sections to the new `DecoTape` API
+    - kept the current section structure and title treatment intact so Phase 3 concept work remains open
 
 ## Decisions
 
@@ -90,8 +95,8 @@
 
 ## Pending
 
-1. Commit Slice 2 from `plan.md`.
-2. Execute Slice 3 and stop at the required user checkpoint after the landing-facing validation slice.
+1. Present the Slice 3 checkpoint and wait for user approval before commit.
+2. Commit Slice 3 from `plan.md` once approved.
 3. Execute Slice 4 after the landing validation is accepted.
 
 ## Risks / Notes
@@ -118,7 +123,10 @@
 - `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx` -> pass
 - `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx` -> pass
 - `git diff --check -- src/shared/ui/common/NoteSurface.tsx` -> pass
+- `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+- `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+- `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
 
 ## Resume
 
-- Next prompt: "Commit Slice 2 and execute Slice 3 from `plan.md` for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Approve or request changes for the Slice 3 landing checkpoint in `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Slice 4 complete and ready to commit. Review and final verification are next.
+- Status: Branch implementation complete. Final hardening/review passed; one small hardening/refactor commit is pending.
 
 ## Completed
 
@@ -67,6 +67,13 @@
     - shifted dashboard tape usage to a quieter default treatment
     - reduced app-side hover motion so the authenticated surface stays more restrained than landing
     - visually checked `/dashboard` against the already running local dev server on port `3000`
+19. Committed Slice 4 as `da53cd0` (`💄 style: apply note foundation to dashboard surfaces`).
+20. Ran hardening, review, and final verification:
+    - tightened the remaining `transition-all` usage in the touched landing files
+    - no blocking findings remained under `pr-review-check`
+    - no blocking findings remained under `web-design-guidelines`
+    - final lint/diff verification passed
+    - desktop and mobile-width visual spot-checks passed on landing and dashboard
 
 ## Decisions
 
@@ -101,9 +108,8 @@
 
 ## Pending
 
-1. Commit Slice 4 from `plan.md`.
-2. Run Hardening, Review, and Final Verify from the accepted plan.
-3. Prepare the branch closeout summary.
+1. Commit the final hardening/refactor follow-up.
+2. Prepare the branch closeout summary.
 
 ## Risks / Notes
 
@@ -136,7 +142,11 @@
 - `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
 - `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
 - Playwright visual spot-check -> pass (`http://127.0.0.1:3000/dashboard`)
+- `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'` -> pass
+- Playwright mobile-width spot-check -> pass (`http://127.0.0.1:3000/`, `http://127.0.0.1:3000/dashboard`)
 
 ## Resume
 
-- Next prompt: "Commit Slice 4, then run review and final verification for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Commit the hardening/refactor follow-up and summarize branch closeout for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -1,0 +1,116 @@
+# Handoff
+
+## Context
+
+- Branch: `ui/17--refresh-design-foundation-codex`
+- Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
+- Status: Slice 1 complete and ready to commit. Slice 2 is next.
+
+## Completed
+
+1. Resolved the session artifact root at `.agent/sessions/[#17]ui--refresh-design-foundation-codex/`.
+2. Reviewed the Phase 2 design-foundation requirements in `docs/MASTER-PLAN.md`.
+3. Reviewed the current scaffold and shared-UI placement rules in `docs/SCAFFOLD_STRUCTURE.md`.
+4. Reviewed the current visual baseline in:
+   - `src/app/globals.css`
+   - landing widgets
+   - dashboard widgets
+   - existing shared helpers in `src/shared/ui/common`
+5. Wrote `spec.md` with:
+   - preserved color and identity constraints
+   - the handwritten note / memo / diary direction
+   - the `Zieglers` brick-by-brick progress metaphor
+   - the squared-corner surface constraint
+   - the requirement to distinguish shared surfaces from page-local composition
+   - a research decision of `required`
+6. Wrote `research.md` with:
+   - a keep/refine/remove audit of the current visual language
+   - an option comparison for how Phase 2 should be executed
+   - the recommendation to build a low-regret foundation now and defer higher-variance page concept choices
+   - the recommendation that the next landing branch begin with three concept directions
+7. Wrote `plan.md` and saved `plans/01-branch-baseline.md` with four execution slices covering:
+   - low-level theme values and accent helpers
+   - a shared note-surface primitive
+   - representative landing adoption
+   - representative dashboard adoption
+8. Updated project-level guidance in `AGENTS.md` so future design-led UI branches:
+   - prefer `frontend-design` as the primary lens
+   - keep `frontend-architecture-rules` as the structural guardrail
+   - require `web-design-guidelines` during Review
+9. Updated the global `branch-cycle-orchestrator` skill to mirror that routing and review behavior for future UI branches.
+10. Replanned the branch after user confirmation:
+   - Slice 1 now explicitly adds semantic support roles before any broader color expansion
+   - the branch now records `frontend-design` as the primary lens
+   - the branch now records `web-design-guidelines` as a mandatory review lens
+   - the downstream landing recommendation is now:
+     - concept-study pass first
+     - choose one concept
+     - compare three variants within that concept
+11. Executed Slice 1 and kept it intentionally low-level:
+    - added note-material semantic support roles in `src/app/globals.css`
+    - refined `DecoTape` into a configurable shared accent helper
+    - refined `GridPatternBackground` so tone/density are token-backed and reusable
+
+## Decisions
+
+- This branch is not a full landing/dashboard redesign branch.
+- The branch should test how far the upgraded design workflow can push quality without discarding the current product identity.
+- The current token palette in `src/app/globals.css` is fixed as the base palette; additions are allowed only when they are minimal and clearly justified as shared-system value.
+- The design direction must preserve:
+  - warm pastel and cozy color character
+  - the `Zieglers` name and brick-by-brick progress feeling
+  - a handwritten note and memo-paper sensibility
+  - squared paper-like corner treatment
+- Shared design surfaces belong in `src/shared/ui/common`; page-specific composition should stay local unless reuse is proven.
+- Existing `DecoTape` and `GridPatternBackground` should be audited rather than assumed correct as-is.
+- The branch should not overfit shared UI to the current implementation.
+- The accepted research direction is:
+  - refine low-level accents and theme roles
+  - add one shared paper/note surface primitive
+  - validate on a few representative existing sections
+  - defer concept-sensitive decisions such as section-header systems and major typography changes
+- The corrected branch skill routing is:
+  - primary branch lens: `frontend-design`
+  - structural guardrail: `frontend-architecture-rules`
+  - mandatory review lens: `web-design-guidelines`
+- The branch now also includes a narrow workflow/documentation correction so future UI branches apply those same lenses more consistently.
+- The next landing branch should:
+  - run a lightweight concept-study pass first
+  - select one concept direction
+  - compare three landing variants inside the selected concept before committing to the full build
+- The current branch should prefer semantic support roles over brand-hue expansion:
+  - derive new note-material roles from the existing palette first
+  - add a small support asset only when the current palette cannot express a required material role cleanly in light and dark themes
+
+## Pending
+
+1. Commit Slice 1 from `plan.md`.
+2. Execute Slice 2 from `plan.md`.
+3. Execute Slice 3 and stop at the required user checkpoint after the landing-facing validation slice.
+4. Execute Slice 4 after the landing validation is accepted.
+
+## Risks / Notes
+
+- The main risk is scope drift into full page redesign work during a branch that is supposed to remain at the shared-foundation level.
+- Over-extracting page-specific compositions into `src/shared/ui/common` would weaken the scaffold and create low-value abstractions.
+- Under-defining the shared design rules would make the follow-up landing and dashboard branches diverge again.
+- Another key risk is accidentally locking in still-unstable page-level choices before the next landing branch has a chance to compare concepts.
+
+## Verification
+
+- `git branch --show-current` -> pass (`ui/17--refresh-design-foundation-codex`)
+- `git status --short` -> pass (clean working tree before artifact creation)
+- `rg -n "Phase 2 - Design Foundation Refresh|refresh-design-foundation" docs/MASTER-PLAN.md` -> pass
+- `rg -n "## Recommendation|Option C|three concept directions|shared note/paper surface" '.agent/sessions/[#17]ui--refresh-design-foundation-codex/research.md'` -> pass
+- `rg -n '## Slice 1|## Slice 2|## Slice 3|## Slice 4|User checkpoint: `required`' '.agent/sessions/[#17]ui--refresh-design-foundation-codex/plan.md'` -> pass
+- `rg -n "frontend-design|web-design-guidelines|design-led UI branches" AGENTS.md` -> pass
+- `rg -n "design-led UI branches|frontend-design|web-design-guidelines|responsive hierarchy" /Users/nagi/.agents/skills/branch-cycle-orchestrator/SKILL.md` -> pass
+- `cmp -s '.agent/sessions/[#17]ui--refresh-design-foundation-codex/plan.md' '.agent/sessions/[#17]ui--refresh-design-foundation-codex/plans/02-design-led-routing.md'` -> pass
+- `git diff --check -- '.agent/sessions/[#17]ui--refresh-design-foundation-codex'` -> pass
+- `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+
+## Resume
+
+- Next prompt: "Commit Slice 1 and execute Slice 2 from `plan.md` for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Slice 3 implemented and verified. Waiting at the required user checkpoint before commit.
+- Status: Slice 4 complete and ready to commit. Review and final verification are next.
 
 ## Completed
 
@@ -61,6 +61,12 @@
     - applied `NoteSurface` to the representative paper wrappers in `MethodSection` and `CtaSection`
     - switched those sections to the new `DecoTape` API
     - kept the current section structure and title treatment intact so Phase 3 concept work remains open
+17. Committed Slice 3 as `0186c7a` (`💄 style: apply note foundation to landing sections`).
+18. Executed Slice 4 for dashboard validation:
+    - applied `NoteSurface` to the representative stat and chart wrappers in `DashboardSummary` and `DashboardCharts`
+    - shifted dashboard tape usage to a quieter default treatment
+    - reduced app-side hover motion so the authenticated surface stays more restrained than landing
+    - visually checked `/dashboard` against the already running local dev server on port `3000`
 
 ## Decisions
 
@@ -95,9 +101,9 @@
 
 ## Pending
 
-1. Present the Slice 3 checkpoint and wait for user approval before commit.
-2. Commit Slice 3 from `plan.md` once approved.
-3. Execute Slice 4 after the landing validation is accepted.
+1. Commit Slice 4 from `plan.md`.
+2. Run Hardening, Review, and Final Verify from the accepted plan.
+3. Prepare the branch closeout summary.
 
 ## Risks / Notes
 
@@ -126,7 +132,11 @@
 - `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
 - `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
 - `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+- `pnpm exec biome check src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- Playwright visual spot-check -> pass (`http://127.0.0.1:3000/dashboard`)
 
 ## Resume
 
-- Next prompt: "Approve or request changes for the Slice 3 landing checkpoint in `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Commit Slice 4, then run review and final verification for `ui/17--refresh-design-foundation-codex`."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/handoff.md
@@ -4,7 +4,7 @@
 
 - Branch: `ui/17--refresh-design-foundation-codex`
 - Goal: refresh the shared design foundation for the note/paper visual system before the landing and dashboard page-refresh branches begin.
-- Status: Post-review grid-visibility fix applied and ready to commit.
+- Status: Post-review grid-visibility fix committed. Branch is complete again.
 
 ## Completed
 
@@ -78,6 +78,7 @@
 22. Applied a post-review shared-foundation fix for `GridPatternBackground` visibility:
     - removed the double attenuation between `--note-grid` and the component-level `tone` opacity
     - kept the fix in `src/app/globals.css` so all current call sites inherit the corrected grid visibility
+23. Committed the grid-visibility follow-up as `9b98f0a` (`🐛 fix: restore note grid visibility`).
 
 ## Decisions
 
@@ -112,8 +113,7 @@
 
 ## Pending
 
-1. Commit the grid-visibility follow-up.
-2. Prepare the branch closeout summary.
+1. Prepare the branch closeout summary.
 
 ## Risks / Notes
 
@@ -156,4 +156,4 @@
 
 ## Resume
 
-- Next prompt: "Commit the grid-visibility follow-up and summarize closeout for `ui/17--refresh-design-foundation-codex`."
+- Next prompt: "Summarize closeout for `ui/17--refresh-design-foundation-codex` including the grid-visibility follow-up."

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -174,3 +174,27 @@
   - switched the `MethodSection` `NoteSurface` class merge to `cn(...)` instead of template-string concatenation
 - Task checklist: complete
 - Slice checkpoint: required, pending user approval before commit.
+
+## 2026-03-19 - Execution Slice 4
+
+- Started Slice 4 after the landing checkpoint was approved and committed.
+- Binding lens and guardrail:
+  - primary lens: `frontend-design`
+  - structural guardrail: `frontend-architecture-rules`
+- TDD cycle:
+  - RED: dashboard summary and chart widgets still depended on duplicated local paper-card border/shadow wrappers, so the app surface had not yet validated the shared note foundation
+  - GREEN: replaced the repeated outer `Card` shell styling in `DashboardSummary` and `DashboardCharts` with `NoteSurface` and updated tape usage to the quieter shared accent treatment
+  - REFACTOR: reduced app-side hover theatrics by removing the more ornamental rotation/tape-disappear behavior and kept the chart internals untouched
+- Applied the foundation conservatively on the authenticated app surface:
+  - `DashboardSummary` now uses `NoteSurface` for each stat card while preserving the existing header/content structure
+  - `DashboardCharts` now uses `NoteSurface` for both chart containers, with chart logic and internals left local
+  - tape remains present as an identity cue, but with quieter presentation than the landing surface
+- Verification for Slice 4:
+  - `pnpm exec biome check src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+  - `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+  - `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+- Visual check:
+  - reviewed `http://127.0.0.1:3000/dashboard` in Playwright against the already running local dev server
+  - confirmed the app-side cards read as the same note material system without inheriting the landing slice's more playful motion
+- Task checklist: complete
+- Slice 4 is ready to commit as the dashboard-surface validation slice.

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -225,3 +225,18 @@
   - E2E expectation: `recommended`
 - Follow-up commit:
   - committed the hardening/refactor cleanup as `d7a01a9` (`♻️ refactor: tighten note section motion transitions`)
+
+## 2026-03-22 - Review follow-up: grid visibility
+
+- Addressed post-review feedback on `GridPatternBackground` visibility.
+- TDD cycle:
+  - RED: `--note-grid` was defined with `color-mix(..., transparent)` while `GridPatternBackground` also applied element opacity, causing the grid lines to become effectively invisible at default call sites
+  - GREEN: moved opacity responsibility fully back to `GridPatternBackground` by redefining `--note-grid` as an opaque hue token in light and dark themes
+  - REFACTOR: kept the fix inside `src/app/globals.css` so existing landing, dashboard, and not-found call sites inherit the corrected visibility without page-local overrides
+- Verification:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/GridPatternBackground.tsx` -> pass
+  - `pnpm exec eslint src/shared/ui/common/GridPatternBackground.tsx` -> pass
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- Visual verification note:
+  - attempted browser-based recheck after the patch, but Playwright browser launch failed in the current environment
+  - the fix is constrained to the shared token/source-of-truth layer and does not require call-site changes

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -1,0 +1,122 @@
+# Log
+
+## 2026-03-18 - Cycle setup
+
+- Resolved the session artifact root for `ui/17--refresh-design-foundation-codex` as `.agent/sessions/[#17]ui--refresh-design-foundation-codex/`.
+- Reviewed the Phase 2 guidance in `docs/MASTER-PLAN.md`, the project scaffold rules in `docs/SCAFFOLD_STRUCTURE.md`, and the current landing/dashboard design baseline in the codebase.
+- Confirmed the working tree was clean before creating new session artifacts.
+- Wrote `spec.md` to fix the branch goal, scope, preserved identity constraints, and the required audit-first research decision for the design-foundation refresh.
+- Initialized `handoff.md` so the next branch-cycle stage can continue from an explicit Spec checkpoint.
+
+## 2026-03-19 - Research
+
+- Re-read the accepted `spec.md`, `handoff.md`, and Phase 2 roadmap constraints before narrowing the branch direction.
+- Reviewed the current local baseline again across:
+  - `src/app/globals.css`
+  - landing widgets
+  - dashboard widgets
+  - `src/app/not-found.tsx`
+  - `src/shared/ui/common`
+  - `components.json`
+- Read the required supporting docs and planner inputs:
+  - `docs/MASTER-PLAN.md`
+  - `docs/SCAFFOLD_STRUCTURE.md`
+  - `docs/PRD.md`
+  - `docs/TECH_REFERENCE.md`
+  - `tdd` skill
+  - `branch-research-gate`
+  - `branch-planner`
+- Incorporated the user's clarification that this branch should explore how far the upgraded design workflow can improve quality, but without treating the current UI as a failure to replace.
+- Compared three viable branch strategies:
+  - conservative extraction from current implementation
+  - concept-first redesign in the current branch
+  - flexible foundation now with concept exploration deferred to the next landing branch
+- Wrote `research.md` with a decision-ready recommendation:
+  - keep the branch as a low-regret design-foundation branch
+  - preserve identity and palette
+  - extract only low-level note/paper/tape primitives
+  - leave section-level and page-level concept decisions for Phase 3
+  - start the next landing branch with three concept directions
+
+## 2026-03-19 - Planner
+
+- Used the accepted research recommendation as the binding planning input.
+- Wrote the latest accepted execution plan to `plan.md`.
+- Archived the baseline plan snapshot to `plans/01-branch-baseline.md`.
+- Planned four execution slices:
+  - Slice 1: note foundation theme values and low-level accents
+  - Slice 2: shared `NoteSurface` primitive
+  - Slice 3: representative landing validation
+  - Slice 4: representative dashboard validation
+- Marked Slice 3 as the only required user checkpoint because it is the first visible application of the new shared direction on a user-facing page.
+
+## 2026-03-19 - Skill routing correction
+
+- User clarified that the branch should more explicitly exercise the upgraded design workflow rather than treating architecture constraints as the main branch lens.
+- Re-evaluated the branch against the orchestrator's UI-routing intent and corrected the recommended skill posture:
+  - `frontend-design` should be the primary branch lens for this UI design-foundation work
+  - `frontend-architecture-rules` should remain the structural and boundary guardrail
+  - `web-design-guidelines` should be mandatory during Review because the branch changes user-facing UI and shared visual language
+- Updated `research.md` and `handoff.md` to reflect the corrected skill routing.
+- Deferred the corresponding `plan.md` update because the user explicitly asked to review the skill correction first.
+
+## 2026-03-19 - Workflow guidance update
+
+- User requested that the improvement not stop at the current branch artifacts and instead be reflected in the shared workflow guidance for future UI branches.
+- Updated the current branch `spec.md` so the narrowly scoped workflow/documentation correction is explicit branch scope rather than an untracked side task.
+- Updated `AGENTS.md` with stronger project-level guidance for design-led UI branches:
+  - prefer `frontend-design` as the primary lens for visual-system and user-facing refresh work
+  - keep `frontend-architecture-rules` as the structural guardrail
+  - require `web-design-guidelines` during Review for user-facing UI changes
+- Updated the global `branch-cycle-orchestrator` skill so the shared stage/routing rules match the project-level guidance:
+  - design-led `react-ui` branches now prefer `frontend-design` as the primary lens
+  - `frontend-architecture-rules` stays active as a required guardrail
+  - `web-design-guidelines` is now explicitly mandatory for Review on design-led user-facing UI branches
+- Deferred `plan.md` alignment until after the user reviews the workflow changes.
+
+## 2026-03-19 - Replan
+
+- User accepted the clarified color-token direction:
+  - do not broaden the core brand hue set by default
+  - add semantic support roles first
+  - add only minimal support assets if existing brand values cannot express a material role cleanly
+- User also accepted the downstream landing-flow change:
+  - concept-study pass first
+  - select one concept direction
+  - compare three landing variants within the chosen concept
+- Updated `research.md` so the accepted recommendation for the next landing branch reflects that concept-selection flow.
+- Rewrote `plan.md` so the branch now records:
+  - `frontend-design` as the primary branch lens
+  - `frontend-architecture-rules` as the structural guardrail
+  - `web-design-guidelines` as the mandatory review lens
+  - semantic support-role work in Slice 1
+  - explicit protection for the downstream concept-study -> 3-variant landing process
+- Archived the new accepted plan snapshot to `plans/02-design-led-routing.md`.
+
+## 2026-03-19 - Execution Slice 1
+
+- Started Slice 1 from `plan.md` with the accepted routing:
+  - primary lens: `frontend-design`
+  - structural guardrail: `frontend-architecture-rules`
+- Kept the slice constrained to low-level material roles and accent helpers only:
+  - no page-level composition changes
+  - no section-level shared abstractions
+  - no core brand-hue expansion
+- Updated `src/app/globals.css` to add semantic support roles for note-like materials:
+  - `--note-surface`
+  - `--note-surface-raised`
+  - `--note-stroke`
+  - `--note-tape`
+  - `--note-grid`
+  - `--note-shadow-color`
+- Mapped those roles through `@theme inline` so shared UI can consume token-backed utilities without falling back to ad hoc color recipes.
+- Refined `src/shared/ui/common/DecoTape.tsx` into a more reusable low-level accent:
+  - added `size` variants
+  - added `tone` variants
+  - switched to the new note-material tokens
+- Refined `src/shared/ui/common/GridPatternBackground.tsx` so density and tone are configurable and the grid color comes from `--note-grid` instead of a direct brand-color reference.
+- Verification for Slice 1:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- Slice 1 is ready to commit as the note-material token and accent-helper foundation.

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -146,3 +146,31 @@
   - `git diff --check -- src/shared/ui/common/NoteSurface.tsx` -> pass
 - Task checklist: complete
 - Slice 2 is ready to commit as the shared note-surface primitive.
+
+## 2026-03-19 - Execution Slice 3
+
+- Started Slice 3 after committing the shared `NoteSurface` primitive.
+- Binding lens and guardrail:
+  - primary lens: `frontend-design`
+  - structural guardrail: `frontend-architecture-rules`
+- TDD cycle:
+  - RED: `MethodSection` and `CtaSection` still carried local paper-surface recipes, so the new foundation was unproven on a real landing page slice
+  - GREEN: replaced the repeated paper wrappers in both sections with `NoteSurface` and updated tape usage to the new shared helper API
+  - REFACTOR: kept the section-title treatment and content structure intact, and avoided broader layout or typography changes that would pre-empt the later concept-study pass
+- Applied the foundation conservatively:
+  - `MethodSection` step cards now use `NoteSurface` with local rotation retained as a page-local accent
+  - the icon chip inside each step now uses note-material tokens instead of local brand-opacity recipes
+  - `CtaSection` now uses `NoteSurface` for the main paper panel and a larger shared tape accent
+  - the CTA button shadow now uses `--note-shadow-color` so the section reads as part of the same material system
+- Explicitly did not change:
+  - section information architecture
+  - the current title underline system
+  - landing hero concept or page-level rhythm
+- Verification for Slice 3:
+  - `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+  - `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+  - `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx` -> pass
+- Checkpoint feedback update:
+  - switched the `MethodSection` `NoteSurface` class merge to `cn(...)` instead of template-string concatenation
+- Task checklist: complete
+- Slice checkpoint: required, pending user approval before commit.

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -98,6 +98,10 @@
 - Started Slice 1 from `plan.md` with the accepted routing:
   - primary lens: `frontend-design`
   - structural guardrail: `frontend-architecture-rules`
+- TDD cycle:
+  - RED: the current codebase had no semantic note-material roles, so shared helpers still depended on copied brand-opacity recipes and direct brand-color references
+  - GREEN: added note-material support roles to `src/app/globals.css` and rewired `DecoTape` and `GridPatternBackground` to consume those shared roles
+  - REFACTOR: simplified helper props to low-level size/tone and density/tone controls so the slice stayed reusable without introducing page semantics
 - Kept the slice constrained to low-level material roles and accent helpers only:
   - no page-level composition changes
   - no section-level shared abstractions
@@ -119,4 +123,26 @@
   - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
   - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
   - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx` -> pass
+- Task checklist: complete
 - Slice 1 is ready to commit as the note-material token and accent-helper foundation.
+
+## 2026-03-19 - Execution Slice 2
+
+- Started Slice 2 from `plan.md` after committing the low-level token/helper foundation.
+- Binding lens and guardrail:
+  - primary lens: `frontend-design`
+  - structural guardrail: `frontend-architecture-rules`
+- TDD cycle:
+  - RED: landing and dashboard surfaces still repeated paper-container recipes instead of having one shared square-corner note wrapper
+  - GREEN: added `src/shared/ui/common/NoteSurface.tsx` as a shared material wrapper that composes the existing shadcn `Card`
+  - REFACTOR: kept the API intentionally low-level with only `tone` and `depth` variants, preserving the existing `Card` prop surface and avoiding page-role props
+- Enforced the slice constraints explicitly:
+  - reused the existing `Card` primitive instead of introducing a parallel structure
+  - kept spacing and composition concerns local so the component remains a paper-material surface, not a page block
+  - added `data-tone` and `data-depth` only as low-level state markers
+- Verification for Slice 2:
+  - `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx` -> pass
+  - `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx` -> pass
+  - `git diff --check -- src/shared/ui/common/NoteSurface.tsx` -> pass
+- Task checklist: complete
+- Slice 2 is ready to commit as the shared note-surface primitive.

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -223,3 +223,5 @@
     - `http://127.0.0.1:3000/dashboard`
 - Branch closeout classification:
   - E2E expectation: `recommended`
+- Follow-up commit:
+  - committed the hardening/refactor cleanup as `d7a01a9` (`♻️ refactor: tighten note section motion transitions`)

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -198,3 +198,28 @@
   - confirmed the app-side cards read as the same note material system without inheriting the landing slice's more playful motion
 - Task checklist: complete
 - Slice 4 is ready to commit as the dashboard-surface validation slice.
+
+## 2026-03-19 - Hardening / Review / Final Verify
+
+- Hardening audit on the touched design files checked:
+  - remaining ad-hoc opacity/shadow recipes that should have moved into the shared note foundation
+  - whether any page-local composition leaked into `src/shared/ui/common`
+  - whether theme additions stayed within semantic support roles rather than expanding the brand hue set
+  - responsive hierarchy, readability, focus affordances, and motion restraint on the landing and dashboard validation slices
+- Hardening fix applied:
+  - replaced the remaining `transition-all` usage in the touched landing sections with explicit transition properties to align with the UI guideline review lens
+- `pr-review-check` findings:
+  - no blocking correctness, regression, or shared/local-boundary findings remained after the hardening fix
+  - no additional test gap was treated as blocking because this branch changes shared visual surfaces rather than data or interaction logic
+- `web-design-guidelines` findings:
+  - no blocking accessibility or UI-guideline issues remained in the touched files after tightening the transition scopes
+  - landing keeps the more playful page-local accents while dashboard now reads as the restrained app-side translation of the same material system
+- Final verification:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx` -> pass
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'` -> pass
+  - Playwright manual visual review -> pass on desktop and mobile-width spot checks for:
+    - `http://127.0.0.1:3000/`
+    - `http://127.0.0.1:3000/dashboard`
+- Branch closeout classification:
+  - E2E expectation: `recommended`

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/log.md
@@ -240,3 +240,5 @@
 - Visual verification note:
   - attempted browser-based recheck after the patch, but Playwright browser launch failed in the current environment
   - the fix is constrained to the shared token/source-of-truth layer and does not require call-site changes
+- Follow-up commit:
+  - committed the review fix as `9b98f0a` (`🐛 fix: restore note grid visibility`)

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plan.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plan.md
@@ -1,0 +1,224 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-design`
+- Secondary skill lens: `frontend-architecture-rules`
+- Mandatory review lens: `web-design-guidelines`
+
+## Scope
+
+- In:
+  - implement the low-regret shared design foundation recommended by `research.md`
+  - preserve the existing brand palette while adding only the minimum semantic support roles needed for paper, tape, line, and shadow behavior
+  - refine the existing shared accent helpers in `src/shared/ui/common`
+  - add one reusable low-level note/paper surface component in `src/shared/ui/common`
+  - validate the foundation on a small number of representative landing and dashboard sections without redesigning those pages end-to-end
+  - keep the branch compatible with a Phase 3 flow that:
+    - begins with a lightweight concept-study pass
+    - selects one concept direction
+    - compares three landing variants inside that chosen concept
+- Out:
+  - full landing-page redesign
+  - full dashboard redesign
+  - final concept selection among the future landing-page directions
+  - shared page-header systems, hero shells, or section-storytelling components
+  - broad typography overhauls unless a low-risk shared requirement appears during execution and is explicitly replanned
+  - broad expansion of core brand hues in `src/app/globals.css`
+
+## Interface / Type Changes
+
+- No API, data, or route contract changes are planned.
+- Planned shared UI additions/refinements:
+  - refine `src/shared/ui/common/DecoTape.tsx`
+  - refine `src/shared/ui/common/GridPatternBackground.tsx`
+  - add `src/shared/ui/common/NoteSurface.tsx`
+- Planned global theme changes:
+  - add minimal semantic support roles in `src/app/globals.css` for reusable note materials such as paper surface, tape fill, line/stroke, and shadow behavior
+  - derive those roles from the existing brand palette first
+  - only add a small support asset if the existing palette cannot express a required material role cleanly in both light and dark themes
+  - do not expand the core brand hue set unless execution proves a true blocker and the branch is explicitly replanned
+- Explicit non-additions for this branch:
+  - no shared section-header component
+  - no shared landing hero composition component
+  - no shared dashboard page-shell component
+
+## Slice 1
+
+- Goal:
+  - Formalize the low-level note material system in theme values and shared accent helpers without widening into page structure.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `src/app/globals.css` keeps the current brand palette intact and adds only the minimum semantic support roles needed for reusable paper/tape/line/shadow behavior
+  - if a support asset is added, it is justified as a material-support need rather than a core brand-hue expansion
+  - `DecoTape` and `GridPatternBackground` become configurable, restrained shared accents rather than fixed one-off recipes
+  - no page-specific layout or story semantics are introduced into the common layer
+- Out of scope:
+  - adding the main paper container primitive
+  - updating landing/dashboard widgets
+- Planned files:
+  - `src/app/globals.css`
+  - `src/shared/ui/common/DecoTape.tsx`
+  - `src/shared/ui/common/GridPatternBackground.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Map the repeated inline material values from the audit to the smallest justified set of semantic support roles.
+  2. Update `globals.css` so those roles are derived from the current palette wherever possible.
+  3. Refine `DecoTape` props and classes to support restrained shared usage.
+  4. Refine `GridPatternBackground` so it remains an atmospheric opt-in layer rather than a hard-coded page blanket.
+- RED:
+  - Compare the current repeated paper/tape style recipes against the research recommendation and fail on the lack of reusable semantic support roles and helper flexibility.
+- GREEN:
+  - Add the minimal support roles and helper refinements needed for a stable low-level material foundation.
+- REFACTOR:
+  - Trim any speculative tokens, normalize helper prop names, and remove any common-layer logic that implies page-specific composition.
+- Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+- Failure recovery:
+  - If the theme additions start drifting into broad palette expansion, collapse back to the smallest semantic support-role set and defer extra color exploration to the later concept branch.
+- Commit:
+  - `:art: style: refine note material tokens and accents`
+
+## Slice 2
+
+- Goal:
+  - Introduce one reusable square-corner note/paper surface primitive that captures the shared paper contract without freezing page-level composition.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the new shared component provides a composable note/paper wrapper with the agreed visual foundation
+  - the component API stays low-level and does not encode page or feature semantics
+  - the component is expressive enough to replace repeated paper-surface class recipes in later slices
+- Out of scope:
+  - shared section headers
+  - hero/dashboard-specific compound components
+- Planned files:
+  - `src/shared/ui/common/NoteSurface.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Define the smallest viable prop surface for the shared note container.
+  2. Implement the paper/tape-friendly wrapper using the Slice 1 support roles.
+  3. Keep the component composable for different child content without page assumptions.
+  4. Recheck the API against the research warning about over-extraction.
+- RED:
+  - Fail on the current inability to reuse a consistent note/paper container without copying local border, shadow, background, and corner recipes.
+- GREEN:
+  - Add the shared note-surface primitive.
+- REFACTOR:
+  - Simplify variant names, keep props explicit and minimal, and remove any styling affordance that is too concept-specific for Phase 2.
+- Verify:
+  - `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx`
+  - `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx`
+  - `git diff --check -- src/shared/ui/common/NoteSurface.tsx`
+- Failure recovery:
+  - If the component starts needing page-role props such as `hero`, `dashboard`, or `cta`, reduce it back to a lower-level surface primitive and leave those concerns local.
+- Commit:
+  - `:sparkles: feat: add shared note surface primitive`
+
+## Slice 3
+
+- Goal:
+  - Validate the new foundation on a small public-facing landing sample without turning this branch into the landing redesign branch.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the selected landing sections adopt the new foundation and read more intentional and consistent than the current inline recipes
+  - the changes stay conservative enough that the next landing branch can still run a concept-study pass, select one direction, and compare three variants meaningfully
+  - no hero-level or page-structure redesign slips into this slice
+- Out of scope:
+  - reworking the landing hero
+  - changing page information architecture
+  - locking in a final landing section-title system
+- Planned files:
+  - `src/widgets/landing/MethodSection.tsx`
+  - `src/widgets/landing/CtaSection.tsx`
+- User checkpoint: `required`
+- Task checklist:
+  1. Replace repeated paper/tape recipes in the selected landing sections with the new shared foundation.
+  2. Keep current content structure intact while improving the note/paper treatment.
+  3. Remove ornamental styling that the research marked as unstable or too page-specific.
+  4. Recheck that the result still leaves room for the later concept-study and 3-variant landing flow.
+- RED:
+  - Fail on the selected landing sections still depending on ad-hoc local paper/tape styling that cannot prove the foundation works.
+- GREEN:
+  - Apply the shared foundation to the representative landing sections.
+- REFACTOR:
+  - Strip out any style move that starts acting like a concept decision instead of a reusable foundation validation.
+- Verify:
+  - `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+- Failure recovery:
+  - If a section only looks correct after introducing new layout or typography decisions, back that part out and keep only the low-regret foundation adoption.
+- Commit:
+  - `:lipstick: style: apply note foundation to landing sections`
+
+## Slice 4
+
+- Goal:
+  - Validate the same foundation on representative dashboard surfaces so the shared language already works on the authenticated app side.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - selected dashboard sections adopt the shared note foundation without changing data behavior or dashboard structure
+  - the dashboard usage feels like the same system as landing, but not a forced copy of landing composition
+  - chart- or data-specific concerns remain local to the widgets
+- Out of scope:
+  - full dashboard page refresh
+  - changing dashboard data or chart logic
+  - converting every dashboard widget in this branch
+- Planned files:
+  - `src/widgets/dashboard-summary/DashboardSummary.tsx`
+  - `src/widgets/dashboard-charts/DashboardCharts.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Replace repeated outer paper/tape styling in the selected dashboard widgets with the new shared foundation.
+  2. Keep chart internals and data semantics local while unifying the surrounding surface language.
+  3. Confirm the app-surface translation still feels restrained and not overly decorative.
+  4. Recheck that no landing-specific assumptions leaked into dashboard usage.
+- RED:
+  - Fail on the selected dashboard widgets still relying on duplicated local paper-card styling and not yet proving the shared foundation on the app surface.
+- GREEN:
+  - Apply the shared foundation to the representative dashboard widgets.
+- REFACTOR:
+  - Remove any landing-specific styling assumptions and keep the app-side usage tight and reusable.
+- Verify:
+  - `pnpm exec biome check src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+- Failure recovery:
+  - If chart wrappers need special treatment, keep the chart-specific behavior local and limit shared extraction to the outer note surface and accent usage.
+- Commit:
+  - `:lipstick: style: apply note foundation to dashboard surfaces`
+
+## Final Stages
+
+- Hardening:
+  - audit touched files for remaining ad-hoc opacity/shadow recipes that should have moved to the shared foundation
+  - verify that no page-local composition leaked into `src/shared/ui/common`
+  - confirm theme additions stayed within semantic support roles and did not casually expand the core brand palette
+  - for the design-led parts of the branch, verify responsive hierarchy, readability, focus affordances, and motion restraint
+- Review:
+  - run `pr-review-check` plus `web-design-guidelines` as mandatory review lenses
+  - review for over-extraction, weak shared/local boundaries, inconsistent paper/tape usage, and any drift away from the preserved palette and memo identity
+  - check that the branch still leaves room for the later concept-study and 3-variant landing flow
+- Refactor:
+  - apply only fixes justified by hardening/review findings
+  - collapse redundant variants or props if the shared surface API is broader than the research recommendation
+- Final Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'`
+  - manual responsive and visual review on landing and dashboard surfaces
+  - E2E expectation at closeout: `recommended`

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plans/01-branch-baseline.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plans/01-branch-baseline.md
@@ -1,0 +1,205 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-architecture-rules`
+- Secondary skill lens: `frontend-design`
+
+## Scope
+
+- In:
+  - implement the low-regret shared design foundation recommended by `research.md`
+  - preserve the existing semantic token palette while adding only minimal note/paper/tape support values if necessary
+  - refine the existing shared accent helpers in `src/shared/ui/common`
+  - add one reusable low-level note/paper surface component in `src/shared/ui/common`
+  - validate the foundation on a small number of representative landing and dashboard sections without redesigning those pages end-to-end
+  - keep the branch compatible with a later 3-concept landing exploration
+- Out:
+  - full landing-page redesign
+  - full dashboard redesign
+  - final concept selection among the future landing-page directions
+  - shared page-header systems, hero shells, or section-storytelling components
+  - broad typography overhauls unless a low-risk shared requirement appears during execution and is explicitly replanned
+
+## Interface / Type Changes
+
+- No API, data, or route contract changes are planned.
+- Planned shared UI additions/refinements:
+  - refine `src/shared/ui/common/DecoTape.tsx`
+  - refine `src/shared/ui/common/GridPatternBackground.tsx`
+  - add `src/shared/ui/common/NoteSurface.tsx`
+- Planned global theme changes:
+  - minimal additions in `src/app/globals.css` only if needed for shared paper/tape/line/shadow roles
+- Explicit non-additions for this branch:
+  - no shared section-header component
+  - no shared landing hero composition component
+  - no shared dashboard page-shell component
+
+## Slice 1
+
+- Goal:
+  - Formalize the low-level note foundation in theme values and shared accent helpers without widening into page structure.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `src/app/globals.css` keeps the current palette intact and adds only the minimum theme values needed for reusable paper/tape/line/shadow behavior
+  - `DecoTape` and `GridPatternBackground` become configurable, restrained shared accents rather than fixed one-off recipes
+  - no page-specific layout or story semantics are introduced into the common layer
+- Out of scope:
+  - adding the main paper container primitive
+  - updating landing/dashboard widgets
+- Planned files:
+  - `src/app/globals.css`
+  - `src/shared/ui/common/DecoTape.tsx`
+  - `src/shared/ui/common/GridPatternBackground.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Map the repeated inline surface values from the audit to the smallest justified set of shared theme roles.
+  2. Update `globals.css` with only those minimal roles.
+  3. Refine `DecoTape` props and classes to support restrained shared usage.
+  4. Refine `GridPatternBackground` so it remains an atmospheric opt-in layer rather than a hard-coded page blanket.
+- RED:
+  - Compare the current repeated paper/tape style recipes against the research recommendation and fail on the lack of reusable low-level theme roles and helper flexibility.
+- GREEN:
+  - Add the minimal theme values and helper refinements needed for a stable low-level foundation.
+- REFACTOR:
+  - Trim any speculative tokens, normalize helper prop names, and remove any common-layer logic that implies page-specific composition.
+- Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+- Failure recovery:
+  - If the token set starts growing beyond low-level paper/tape/line/shadow roles, collapse it back to the smallest shared-system set and defer concept-specific values to Phase 3.
+- Commit:
+  - `:art: style: refine note foundation tokens and accents`
+
+## Slice 2
+
+- Goal:
+  - Introduce one reusable square-corner note/paper surface primitive that captures the shared paper contract without freezing page-level composition.
+- Binding skill lens:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the new shared component provides a composable note/paper wrapper with the agreed visual foundation
+  - the component API stays low-level and does not encode page or feature semantics
+  - the component is expressive enough to replace repeated paper-surface class recipes in later slices
+- Out of scope:
+  - shared section headers
+  - hero/dashboard-specific compound components
+- Planned files:
+  - `src/shared/ui/common/NoteSurface.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Define the smallest viable prop surface for the shared note container.
+  2. Implement the paper/tape-friendly wrapper using the Slice 1 theme values.
+  3. Keep the component composable for different child content without page assumptions.
+  4. Recheck the API against the research warning about over-extraction.
+- RED:
+  - Fail on the current inability to reuse a consistent note/paper container without copying local border, shadow, background, and corner recipes.
+- GREEN:
+  - Add the shared note-surface primitive.
+- REFACTOR:
+  - Simplify variant names, keep props explicit and minimal, and remove any styling affordance that is too concept-specific for Phase 2.
+- Verify:
+  - `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx`
+  - `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx`
+  - `git diff --check -- src/shared/ui/common/NoteSurface.tsx`
+- Failure recovery:
+  - If the component starts needing page-role props such as `hero`, `dashboard`, or `cta`, reduce it back to a lower-level surface primitive and leave those concerns local.
+- Commit:
+  - `:sparkles: feat: add shared note surface primitive`
+
+## Slice 3
+
+- Goal:
+  - Validate the new foundation on a small public-facing landing sample without turning this branch into the landing redesign branch.
+- Binding skill lens:
+  - `frontend-design`
+- Done criteria:
+  - the selected landing sections adopt the new foundation and read more intentional and consistent than the current inline recipes
+  - the changes stay conservative enough that the next landing branch can still compare multiple concepts meaningfully
+  - no hero-level or page-structure redesign slips into this slice
+- Out of scope:
+  - reworking the landing hero
+  - changing page information architecture
+  - locking in a final landing section-title system
+- Planned files:
+  - `src/widgets/landing/MethodSection.tsx`
+  - `src/widgets/landing/CtaSection.tsx`
+- User checkpoint: `required`
+- Task checklist:
+  1. Replace repeated paper/tape recipes in the selected landing sections with the new shared foundation.
+  2. Keep current content structure intact while improving the note/paper treatment.
+  3. Remove ornamental styling that the research marked as unstable or too page-specific.
+  4. Recheck that the result still leaves room for the later 3-concept landing exploration.
+- RED:
+  - Fail on the selected landing sections still depending on ad-hoc local paper/tape styling that cannot prove the foundation works.
+- GREEN:
+  - Apply the shared foundation to the representative landing sections.
+- REFACTOR:
+  - Strip out any style move that starts acting like a concept decision instead of a reusable foundation validation.
+- Verify:
+  - `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+- Failure recovery:
+  - If a section only looks correct after introducing new layout or typography decisions, back that part out and keep only the low-regret foundation adoption.
+- Commit:
+  - `:lipstick: style: apply note foundation to landing sections`
+
+## Slice 4
+
+- Goal:
+  - Validate the same foundation on representative dashboard surfaces so the shared language already works on the authenticated app side.
+- Binding skill lens:
+  - `frontend-design`
+- Done criteria:
+  - selected dashboard sections adopt the shared note foundation without changing data behavior or dashboard structure
+  - the dashboard usage feels like the same system as landing, but not a forced copy of landing composition
+  - chart- or data-specific concerns remain local to the widgets
+- Out of scope:
+  - full dashboard page refresh
+  - changing dashboard data or chart logic
+  - converting every dashboard widget in this branch
+- Planned files:
+  - `src/widgets/dashboard-summary/DashboardSummary.tsx`
+  - `src/widgets/dashboard-charts/DashboardCharts.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Replace repeated outer paper/tape styling in the selected dashboard widgets with the new shared foundation.
+  2. Keep chart internals and data semantics local while unifying the surrounding surface language.
+  3. Confirm the app-surface translation still feels restrained and not overly decorative.
+  4. Recheck that no landing-specific assumptions leaked into dashboard usage.
+- RED:
+  - Fail on the selected dashboard widgets still relying on duplicated local paper-card styling and not yet proving the shared foundation on the app surface.
+- GREEN:
+  - Apply the shared foundation to the representative dashboard widgets.
+- REFACTOR:
+  - Remove any landing-specific styling assumptions and keep the app-side usage tight and reusable.
+- Verify:
+  - `pnpm exec biome check src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+- Failure recovery:
+  - If chart wrappers need special treatment, keep the chart-specific behavior local and limit shared extraction to the outer note surface and accent usage.
+- Commit:
+  - `:lipstick: style: apply note foundation to dashboard surfaces`
+
+## Final Stages
+
+- Hardening:
+  - audit touched files for remaining ad-hoc opacity/shadow recipes that should have moved to the shared foundation
+  - verify that no page-local composition leaked into `src/shared/ui/common`
+  - confirm token additions stayed minimal and identity-consistent
+- Review:
+  - run a UI-focused review for over-extraction, weak shared/local boundaries, inconsistent paper/tape usage, and any drift away from the preserved palette and memo identity
+  - include a design review check that the branch still leaves room for the later 3-concept landing exploration
+- Refactor:
+  - apply only fixes justified by hardening/review findings
+  - collapse redundant variants or props if the shared surface API is broader than the research recommendation
+- Final Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'`
+  - manual responsive and visual review on landing and dashboard surfaces
+  - E2E expectation at closeout: `recommended`

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plans/02-design-led-routing.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/plans/02-design-led-routing.md
@@ -1,0 +1,224 @@
+# Branch Plan
+
+- Primary classification: `react-ui`
+- Secondary classification: `next-app-router`
+- Primary skill lens: `frontend-design`
+- Secondary skill lens: `frontend-architecture-rules`
+- Mandatory review lens: `web-design-guidelines`
+
+## Scope
+
+- In:
+  - implement the low-regret shared design foundation recommended by `research.md`
+  - preserve the existing brand palette while adding only the minimum semantic support roles needed for paper, tape, line, and shadow behavior
+  - refine the existing shared accent helpers in `src/shared/ui/common`
+  - add one reusable low-level note/paper surface component in `src/shared/ui/common`
+  - validate the foundation on a small number of representative landing and dashboard sections without redesigning those pages end-to-end
+  - keep the branch compatible with a Phase 3 flow that:
+    - begins with a lightweight concept-study pass
+    - selects one concept direction
+    - compares three landing variants inside that chosen concept
+- Out:
+  - full landing-page redesign
+  - full dashboard redesign
+  - final concept selection among the future landing-page directions
+  - shared page-header systems, hero shells, or section-storytelling components
+  - broad typography overhauls unless a low-risk shared requirement appears during execution and is explicitly replanned
+  - broad expansion of core brand hues in `src/app/globals.css`
+
+## Interface / Type Changes
+
+- No API, data, or route contract changes are planned.
+- Planned shared UI additions/refinements:
+  - refine `src/shared/ui/common/DecoTape.tsx`
+  - refine `src/shared/ui/common/GridPatternBackground.tsx`
+  - add `src/shared/ui/common/NoteSurface.tsx`
+- Planned global theme changes:
+  - add minimal semantic support roles in `src/app/globals.css` for reusable note materials such as paper surface, tape fill, line/stroke, and shadow behavior
+  - derive those roles from the existing brand palette first
+  - only add a small support asset if the existing palette cannot express a required material role cleanly in both light and dark themes
+  - do not expand the core brand hue set unless execution proves a true blocker and the branch is explicitly replanned
+- Explicit non-additions for this branch:
+  - no shared section-header component
+  - no shared landing hero composition component
+  - no shared dashboard page-shell component
+
+## Slice 1
+
+- Goal:
+  - Formalize the low-level note material system in theme values and shared accent helpers without widening into page structure.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - `src/app/globals.css` keeps the current brand palette intact and adds only the minimum semantic support roles needed for reusable paper/tape/line/shadow behavior
+  - if a support asset is added, it is justified as a material-support need rather than a core brand-hue expansion
+  - `DecoTape` and `GridPatternBackground` become configurable, restrained shared accents rather than fixed one-off recipes
+  - no page-specific layout or story semantics are introduced into the common layer
+- Out of scope:
+  - adding the main paper container primitive
+  - updating landing/dashboard widgets
+- Planned files:
+  - `src/app/globals.css`
+  - `src/shared/ui/common/DecoTape.tsx`
+  - `src/shared/ui/common/GridPatternBackground.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Map the repeated inline material values from the audit to the smallest justified set of semantic support roles.
+  2. Update `globals.css` so those roles are derived from the current palette wherever possible.
+  3. Refine `DecoTape` props and classes to support restrained shared usage.
+  4. Refine `GridPatternBackground` so it remains an atmospheric opt-in layer rather than a hard-coded page blanket.
+- RED:
+  - Compare the current repeated paper/tape style recipes against the research recommendation and fail on the lack of reusable semantic support roles and helper flexibility.
+- GREEN:
+  - Add the minimal support roles and helper refinements needed for a stable low-level material foundation.
+- REFACTOR:
+  - Trim any speculative tokens, normalize helper prop names, and remove any common-layer logic that implies page-specific composition.
+- Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx`
+- Failure recovery:
+  - If the theme additions start drifting into broad palette expansion, collapse back to the smallest semantic support-role set and defer extra color exploration to the later concept branch.
+- Commit:
+  - `:art: style: refine note material tokens and accents`
+
+## Slice 2
+
+- Goal:
+  - Introduce one reusable square-corner note/paper surface primitive that captures the shared paper contract without freezing page-level composition.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the new shared component provides a composable note/paper wrapper with the agreed visual foundation
+  - the component API stays low-level and does not encode page or feature semantics
+  - the component is expressive enough to replace repeated paper-surface class recipes in later slices
+- Out of scope:
+  - shared section headers
+  - hero/dashboard-specific compound components
+- Planned files:
+  - `src/shared/ui/common/NoteSurface.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Define the smallest viable prop surface for the shared note container.
+  2. Implement the paper/tape-friendly wrapper using the Slice 1 support roles.
+  3. Keep the component composable for different child content without page assumptions.
+  4. Recheck the API against the research warning about over-extraction.
+- RED:
+  - Fail on the current inability to reuse a consistent note/paper container without copying local border, shadow, background, and corner recipes.
+- GREEN:
+  - Add the shared note-surface primitive.
+- REFACTOR:
+  - Simplify variant names, keep props explicit and minimal, and remove any styling affordance that is too concept-specific for Phase 2.
+- Verify:
+  - `pnpm exec biome check src/shared/ui/common/NoteSurface.tsx`
+  - `pnpm exec eslint src/shared/ui/common/NoteSurface.tsx`
+  - `git diff --check -- src/shared/ui/common/NoteSurface.tsx`
+- Failure recovery:
+  - If the component starts needing page-role props such as `hero`, `dashboard`, or `cta`, reduce it back to a lower-level surface primitive and leave those concerns local.
+- Commit:
+  - `:sparkles: feat: add shared note surface primitive`
+
+## Slice 3
+
+- Goal:
+  - Validate the new foundation on a small public-facing landing sample without turning this branch into the landing redesign branch.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - the selected landing sections adopt the new foundation and read more intentional and consistent than the current inline recipes
+  - the changes stay conservative enough that the next landing branch can still run a concept-study pass, select one direction, and compare three variants meaningfully
+  - no hero-level or page-structure redesign slips into this slice
+- Out of scope:
+  - reworking the landing hero
+  - changing page information architecture
+  - locking in a final landing section-title system
+- Planned files:
+  - `src/widgets/landing/MethodSection.tsx`
+  - `src/widgets/landing/CtaSection.tsx`
+- User checkpoint: `required`
+- Task checklist:
+  1. Replace repeated paper/tape recipes in the selected landing sections with the new shared foundation.
+  2. Keep current content structure intact while improving the note/paper treatment.
+  3. Remove ornamental styling that the research marked as unstable or too page-specific.
+  4. Recheck that the result still leaves room for the later concept-study and 3-variant landing flow.
+- RED:
+  - Fail on the selected landing sections still depending on ad-hoc local paper/tape styling that cannot prove the foundation works.
+- GREEN:
+  - Apply the shared foundation to the representative landing sections.
+- REFACTOR:
+  - Strip out any style move that starts acting like a concept decision instead of a reusable foundation validation.
+- Verify:
+  - `pnpm exec biome check src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `pnpm exec eslint src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+  - `git diff --check -- src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx`
+- Failure recovery:
+  - If a section only looks correct after introducing new layout or typography decisions, back that part out and keep only the low-regret foundation adoption.
+- Commit:
+  - `:lipstick: style: apply note foundation to landing sections`
+
+## Slice 4
+
+- Goal:
+  - Validate the same foundation on representative dashboard surfaces so the shared language already works on the authenticated app side.
+- Binding skill lens:
+  - `frontend-design`
+- Structural guardrail:
+  - `frontend-architecture-rules`
+- Done criteria:
+  - selected dashboard sections adopt the shared note foundation without changing data behavior or dashboard structure
+  - the dashboard usage feels like the same system as landing, but not a forced copy of landing composition
+  - chart- or data-specific concerns remain local to the widgets
+- Out of scope:
+  - full dashboard page refresh
+  - changing dashboard data or chart logic
+  - converting every dashboard widget in this branch
+- Planned files:
+  - `src/widgets/dashboard-summary/DashboardSummary.tsx`
+  - `src/widgets/dashboard-charts/DashboardCharts.tsx`
+- User checkpoint: `not required`
+- Task checklist:
+  1. Replace repeated outer paper/tape styling in the selected dashboard widgets with the new shared foundation.
+  2. Keep chart internals and data semantics local while unifying the surrounding surface language.
+  3. Confirm the app-surface translation still feels restrained and not overly decorative.
+  4. Recheck that no landing-specific assumptions leaked into dashboard usage.
+- RED:
+  - Fail on the selected dashboard widgets still relying on duplicated local paper-card styling and not yet proving the shared foundation on the app surface.
+- GREEN:
+  - Apply the shared foundation to the representative dashboard widgets.
+- REFACTOR:
+  - Remove any landing-specific styling assumptions and keep the app-side usage tight and reusable.
+- Verify:
+  - `pnpm exec biome check src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+- Failure recovery:
+  - If chart wrappers need special treatment, keep the chart-specific behavior local and limit shared extraction to the outer note surface and accent usage.
+- Commit:
+  - `:lipstick: style: apply note foundation to dashboard surfaces`
+
+## Final Stages
+
+- Hardening:
+  - audit touched files for remaining ad-hoc opacity/shadow recipes that should have moved to the shared foundation
+  - verify that no page-local composition leaked into `src/shared/ui/common`
+  - confirm theme additions stayed within semantic support roles and did not casually expand the core brand palette
+  - for the design-led parts of the branch, verify responsive hierarchy, readability, focus affordances, and motion restraint
+- Review:
+  - run `pr-review-check` plus `web-design-guidelines` as mandatory review lenses
+  - review for over-extraction, weak shared/local boundaries, inconsistent paper/tape usage, and any drift away from the preserved palette and memo identity
+  - check that the branch still leaves room for the later concept-study and 3-variant landing flow
+- Refactor:
+  - apply only fixes justified by hardening/review findings
+  - collapse redundant variants or props if the shared surface API is broader than the research recommendation
+- Final Verify:
+  - `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
+  - `git diff --check -- src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx '.agent/sessions/[#17]ui--refresh-design-foundation-codex'`
+  - manual responsive and visual review on landing and dashboard surfaces
+  - E2E expectation at closeout: `recommended`

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/research.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/research.md
@@ -1,0 +1,226 @@
+# Research
+
+## Goal
+
+- Decide how this Phase 2 branch should define a stronger shared design foundation without either fossilizing the current landing/dashboard implementation or drifting into full page redesign work.
+- Resolve whether the next landing-page branch should compare multiple visual concepts and what this branch must freeze versus deliberately defer.
+
+## Research Questions
+
+- Which current landing/dashboard visual patterns should be kept, refined, or removed from the shared design language?
+- Which existing motifs have enough cross-page reuse value to belong in `src/shared/ui/common`?
+- How can this branch preserve room for a later 3-concept landing exploration instead of locking the next branch into the current UI?
+- What is the minimum token expansion, if any, that is justified for a reusable paper/note/tape surface system?
+
+## Scope
+
+- In:
+  - inspect the current local design baseline in landing, dashboard, not-found, shared common helpers, and `globals.css`
+  - compare viable branch strategies for Phase 2
+  - recommend a design-foundation boundary that preserves both branch discipline and later creative freedom
+  - identify the minimum shared surface set and the minimum token additions worth planning
+- Out:
+  - selecting the final landing-page redesign concept
+  - implementing the full landing or dashboard refresh
+  - external trend research or framework/vendor browsing
+  - redefining product identity or replacing the established palette
+
+## Current Baseline
+
+- Relevant session artifacts:
+  - `spec.md` fixes the branch intent as an audit-first design-foundation branch and explicitly marks research as required.
+  - `handoff.md` records the main risk as over-extracting page-local patterns into `src/shared/ui/common`.
+- Relevant project documents:
+  - `docs/MASTER-PLAN.md` Phase 2 says this branch should audit the current visual language, lock the refreshed note/paper direction, and implement only the minimum reusable shared surfaces needed before page-level redesign.
+  - `docs/SCAFFOLD_STRUCTURE.md` requires reusable project UI to live in `src/shared/ui/common` and page/screen compositions to remain in widget or route layers.
+  - `docs/PRD.md` confirms landing and dashboard are user-facing MVP surfaces, but does not require their redesign in this branch.
+  - `docs/TECH_REFERENCE.md` confirms Tailwind v4, shadcn/ui, and semantic token usage through `src/app/globals.css`.
+- Current code baseline:
+  - `src/app/globals.css` already defines the warm paper-like palette and semantic color-token contract.
+  - `src/shared/ui/common` currently contains only `BackButton`, `DecoTape`, and `GridPatternBackground`.
+  - Landing and dashboard both already reuse tape, paper-card, border, shadow, and memo-board cues.
+  - `src/app/not-found.tsx` also reuses the same visual language, which confirms some motifs already cross more than one page.
+- Pattern reality from the current implementation:
+  - good visual language exists, but much of it is embedded as repeated inline class recipes such as `bg-primary/5`, `border-primary/10`, repeated shadow tokens, one-off rotations, and local highlight bars
+  - the current common layer captures only the simplest motifs and does not yet define a reusable paper/note surface contract
+
+## Constraints
+
+- Product constraints:
+  - preserve the current warm pastel palette and semantic token base from `src/app/globals.css`
+  - preserve the `Zieglers` identity and the brick-by-brick progress feeling
+  - preserve the handwritten note / memo / diary-decoration tone
+  - preserve sharper, more squared paper-like corners
+- Technical constraints:
+  - keep shared reusable UI in `src/shared/ui/common`
+  - do not move page-specific story/layout compositions into the shared layer
+  - do not bypass semantic tokens with raw Tailwind color decisions when a shared token can express the need
+  - each new React component must live in its own file
+- Workflow constraints:
+  - this branch is Phase 2 design foundation, not Phase 3 page redesign
+  - the branch should reduce ambiguity for the later landing/dashboard refresh branches, not consume their work
+
+## Options Considered
+
+### Option A
+
+- Description:
+  - Extract shared components directly from the current landing/dashboard implementation and standardize around the existing visual recipes with minimal reinterpretation.
+- Pros:
+  - lowest short-term implementation risk
+  - fastest way to reduce repeated inline classes
+  - keeps close continuity with the current baseline
+- Cons:
+  - strongly couples the shared layer to today's page designs
+  - makes the next landing refresh feel like a cleanup pass instead of a real concept exploration
+  - risks canonizing current page-specific decisions such as section-title treatments, hover rotations, and decorative accents
+
+### Option B
+
+- Description:
+  - Skip most foundation work and use this branch to pursue page-level concept exploration immediately, effectively folding landing redesign decisions into Phase 2.
+- Pros:
+  - maximum design freedom right away
+  - easier to judge bold concepts in a full-page context
+- Cons:
+  - violates the intended Phase 2 scope from `docs/MASTER-PLAN.md`
+  - leaves dashboard without a stable shared foundation
+  - makes reusable/common extraction reactive to one chosen page concept rather than deliberate
+  - increases rework risk if the first concept does not generalize to the authenticated app surface
+
+### Option C
+
+- Description:
+  - Build a flexible, low-regret foundation now: refine tokens and low-level accents, introduce one shared note/paper surface, and validate it on a few representative sections while explicitly deferring higher-variance page-concept choices to the next landing branch.
+- Pros:
+  - preserves branch discipline and Phase 2 intent
+  - reduces repeated style recipes without freezing the full current layout language
+  - keeps the next landing branch free to compare three concepts
+  - gives the later dashboard refresh a shared visual base that is not tied to one landing composition
+- Cons:
+  - some later tuning is still likely once a specific landing concept is chosen
+  - requires restraint to avoid turning “foundation” into an underspecified non-change
+  - may leave some currently repeated patterns intentionally unabstracted until Phase 3
+
+## Evidence
+
+- Local findings:
+  - Cross-page motifs already worth preserving:
+    - warm paper/background palette anchored in `globals.css`
+    - squared cards with tactile borders and offset shadows
+    - tape as an identity cue
+    - paper-board atmosphere through optional grid/pattern backdrops
+  - Current motifs that are strong candidates to refine into reusable shared surfaces:
+    - `DecoTape` should become a configurable accent rather than a fixed rectangle recipe
+    - `GridPatternBackground` should remain opt-in and quieter, not a default page blanket
+    - repeated paper-card wrappers suggest a missing shared surface primitive such as a low-level `NoteSurface`
+  - Current motifs that should stay local or be deferred from shared extraction:
+    - the landing hero Mandalart-grid composition
+    - handwritten arrows and annotation doodles
+    - template thumbtack details
+    - dashboard summary/chart/board layouts
+    - shared page-header patterns, which are still too concept-sensitive
+    - aggressive hover rotations on every card, which currently read more ornamental than structural
+  - The current code already proves the risk of overfitting:
+    - section title underline treatments appear in multiple places, but their spacing, weight, and role are inconsistent enough that making a shared section-header component now would likely freeze a still-unstable choice
+    - much of the current “paper” look is expressed through repeated opacity values and custom shadows rather than semantic surface rules
+  - The current code also proves a low-regret foundation is possible:
+    - tape and pattern background are reused in landing, dashboard, and not-found
+    - paper-card treatments recur across landing and dashboard, even though the page compositions differ
+- Keep / Refine / Remove summary:
+  - Keep:
+    - warm pastel token palette
+    - memo/paper identity
+    - squared-corner paper silhouettes
+    - tactile border + shadow depth
+    - tape as a recurring but restrained cue
+  - Refine:
+    - paper-surface contract
+    - tape variants and placement rules
+    - background pattern intensity and usage rules
+    - shadow and border recipes via semantic theme values
+    - brick-by-brick metaphor through rhythm and layering rather than literal bricks
+  - Remove from shared foundation or defer:
+    - one-off hover gimmicks
+    - hero-specific visuals
+    - page-level storytelling composition
+    - current section-title implementation details
+    - handwritten annotations as default shared primitives
+- External findings:
+  - none needed; local project evidence is sufficient for this branch decision
+- Version-sensitive notes:
+  - none; this research is based on stable local project state rather than unstable vendor behavior
+
+## Recommendation
+
+- Recommended option:
+  - `Option C` — build a flexible, low-regret foundation now and defer concept selection to the next landing branch
+- Why this option is preferred:
+  - It matches the Phase 2 role defined in `docs/MASTER-PLAN.md` while addressing the user's valid concern about getting trapped by the current implementation.
+  - It preserves the right things at the right level:
+    - identity and palette are fixed
+    - low-level paper/tape/background rules become shared
+    - page-level composition remains open for exploration
+  - It creates the best setup for the next landing branch to compare three concepts without wasting this branch:
+    - one concept can stay close to the current direction
+    - two concepts can stay identity- and color-consistent while being more creative
+    - all three can build on the same low-regret paper/tape/token foundation
+- Recommended Phase 2 execution boundary:
+  - add only the minimum token/theme roles needed for paper/tape/line/shadow consistency
+  - refine `DecoTape` and `GridPatternBackground`
+  - add one shared low-level paper/note container in `src/shared/ui/common`
+  - prove the foundation on a small number of representative landing/dashboard sections
+  - explicitly defer section-header systems, typography overhauls, and page concept decisions to Phase 3
+- Recommended input for the next landing branch:
+  - begin with a lightweight concept-study pass before committing to the full page implementation
+  - select one concept direction from that study
+  - after the concept is selected, compare three landing variants within the chosen direction before committing to the final page build
+  - suggested concept-study mix:
+    - `Concept 1`: preserve-and-polish current memo-board direction
+    - `Concept 2`: scrapbook/editorial diary direction using the same palette and identity
+    - `Concept 3`: workshop/atelier direction that hints at brick-by-brick construction through stacked modules and structured rhythm
+
+## Tradeoffs
+
+- Cost:
+  - this branch will not resolve every visual decision; some shared primitives may be tuned after the landing concept is chosen
+- Risk:
+  - if the implementation drifts into section-level or page-level abstraction, the shared layer will become too rigid too early
+  - if the implementation stays too timid, the branch may not meaningfully improve the design foundation
+- Follow-up burden:
+  - the next landing branch must still compare and choose a concept
+  - the next dashboard branch must translate the chosen direction to the app surface, which may reveal minor foundation adjustments
+
+## Open Questions
+
+- How visible should the brick-by-brick metaphor be in shared surfaces:
+  - subtle stacked rhythm and structure
+  - or more explicit material cues
+- Should typography changes remain entirely deferred to the landing concept branch, or is one low-risk shared display/body pairing justified sooner?
+- After the concept comparison, will a shared page-header or section-heading treatment emerge as truly cross-page, or should those remain page-local permanently?
+
+## Planning Impact
+
+- Recommended primary skill lens:
+  - `frontend-design`
+- Recommended secondary skill lens:
+  - `frontend-architecture-rules`
+- Mandatory review lens for this branch:
+  - `web-design-guidelines`
+- Architectural implications:
+  - treat `frontend-design` as the branch's primary creative and visual decision lens
+  - use `frontend-architecture-rules` as the binding boundary and file-placement guardrail so shared/common extraction does not drift into page composition
+  - keep `src/shared/ui/common` limited to low-level, reusable design primitives
+  - do not create shared page shells, hero frames, or section-level storytelling components in this branch
+  - use representative adoption on a few existing sections to validate the foundation without broad page rewrites
+  - preserve space for the next landing branch to start with a concept-study pass and then a 3-variant comparison inside the selected concept
+- Constraints the next step must preserve:
+  - no full landing/dashboard redesign in this branch
+  - no extraction of unstable page-level patterns such as section-header systems or story layouts
+  - no raw color drift away from the current token contract
+  - token additions must be minimal and justified by shared surface needs
+  - any visible landing changes in this branch should stay conservative enough that the next 3-concept exploration is still meaningful
+- Conditions that would force a replan:
+  - a planned shared primitive turns out to encode page-specific structure or copy semantics
+  - the token additions expand beyond a minimal paper/tape/line/shadow foundation
+  - a representative adoption requires layout or typography decisions that belong to the later concept branch

--- a/.agent/sessions/[#17]ui--refresh-design-foundation-codex/spec.md
+++ b/.agent/sessions/[#17]ui--refresh-design-foundation-codex/spec.md
@@ -1,0 +1,106 @@
+# Spec
+
+## Goal
+
+- Refresh the shared design foundation that the later landing-page and dashboard refresh branches will build on.
+- Audit the existing landing/dashboard visual language and define a stronger shared note/paper system without redesigning those pages end-to-end in this branch.
+
+## Problem / Background
+
+- The current UI is not considered a failed baseline; the user sees it as already decent and worth preserving in spirit.
+- This branch exists to test how far the newly installed design-oriented skills and workflows can push the product's visual quality while keeping the existing identity intact.
+- The current landing and dashboard already express a warm paper-like memo direction through tape accents, paper-like cards, grid patterns, and note-board cues, but much of that language is still embedded in page-local implementations and repeated inline style recipes rather than a clearly defined shared surface system.
+- `docs/MASTER-PLAN.md` Phase 2 explicitly requires this branch to:
+  - audit the current visual language
+  - lock the refreshed note/paper direction
+  - implement or refine only the minimum reusable shared surfaces needed before page-level redesign work begins
+
+## Desired Outcome
+
+- The branch leaves behind a clear keep/refine/remove audit of the current landing/dashboard visual language.
+- The branch defines and, where appropriate, extracts the minimum reusable note/paper/tape surfaces needed across landing and dashboard into `src/shared/ui/common`.
+- The branch clarifies which visual patterns should remain page-local so later redesign branches do not over-extract layout- or story-specific UI.
+- The shared design direction is strong enough that the later landing and dashboard refresh branches can execute without redefining the visual foundation from scratch.
+- The existing token contract in `src/app/globals.css` remains the shared styling base, with only minimal justified additions if the current token set cannot express a required shared paper/note treatment cleanly.
+
+## Scope
+
+- In:
+  - audit the current landing and dashboard visual language against the current codebase baseline
+  - classify current patterns as keep, refine, or remove
+  - decide which note/paper/tape surfaces belong in `src/shared/ui/common`
+  - keep page-local compositions, storytelling, and one-off decorative patterns out of the shared surface layer unless reuse is clearly justified
+  - preserve the current semantic token contract in `src/app/globals.css`
+  - propose only the minimum new shared tokens that are necessary for the refreshed design foundation
+  - establish shared visual rules that are stable enough for the follow-up landing and dashboard refresh branches
+  - make the minimum workflow/documentation corrections needed so future design-led UI branches use `frontend-design` and `web-design-guidelines` more explicitly
+- Out:
+  - end-to-end redesign of the landing page
+  - end-to-end redesign of the dashboard page
+  - changing the service name or replacing the current product identity
+  - discarding the existing warm pastel color direction
+  - introducing page-only ad-hoc colors or bypassing semantic tokens with raw Tailwind color decisions
+  - implementing unrelated product features such as auth, board flows, or real dashboard data integration
+  - broad branch-workflow redesign beyond the specific UI skill-routing gap discovered in this cycle
+
+## Non-Goals
+
+- Producing a full product-wide design system beyond what this branch needs
+- Rebuilding every existing landing/dashboard widget in the same branch
+- Solving all layout, copy, or information-architecture questions for landing or dashboard
+- Repositioning the product away from its current Mandalart and memo/planning identity
+
+## Constraints / Assumptions
+
+- This branch must follow the documented branch cycle and remain a Phase 2 design-foundation branch.
+- The branch must stay focused on shared design foundations rather than page rebuilds.
+- The current project colors in `src/app/globals.css` must remain the base palette:
+  - main and secondary brand colors stay
+  - current background-family colors stay
+  - additional colors are allowed only when they fit the existing warm, pastel, cozy direction and provide clear shared-system value
+- The service name `Zieglers` must be preserved, and the design direction should support the feeling of stacking progress brick by brick rather than shifting toward a generic productivity aesthetic.
+- The product should continue to feel like handwritten notes and memo paper placed onto a board, with a diary-decoration sensibility rather than a polished enterprise dashboard look.
+- Squared or sharper corner language should remain part of the surface treatment to reinforce the paper/memo direction.
+- `src/app/globals.css` remains the source of truth for semantic tokens and theme values.
+- Reusable project UI belongs in `src/shared/ui/common`; page-specific composition belongs in the appropriate page or widget layer.
+- Existing shared helpers such as `DecoTape` and `GridPatternBackground` are inputs to the audit, not guaranteed final primitives.
+- Each new React component introduced by this branch must live in its own file.
+
+## Acceptance Criteria
+
+- The branch produces an explicit audit of the current landing/dashboard visual language with keep/refine/remove decisions.
+- The branch defines which note/paper/tape surfaces should move into `src/shared/ui/common` and which should remain page-local.
+- The branch preserves the current semantic token contract and introduces only minimal, justified token additions when the existing tokens are insufficient for a shared design need.
+- The resulting design foundation clearly reflects the required identity:
+  - warm pastel palette
+  - `Zieglers` brick-by-brick progress feeling
+  - handwritten note and memo-paper character
+  - squared paper-like surface styling
+- The project workflow guidance is corrected so future design-led UI branches route `frontend-design` more explicitly and include `web-design-guidelines` during review by default.
+- The branch remains within Phase 2 scope and does not absorb full landing/dashboard redesign work.
+- The resulting foundation is clear enough that the Phase 3 landing and dashboard refresh branches can build on it without reopening the same design-foundation decisions.
+
+## Open Questions
+
+- How literal should the bricklayer / brick-by-brick metaphor become in shared UI surfaces versus staying a subtle compositional cue?
+- Which current motifs should survive as shared language after the audit:
+  - tape accents
+  - grid background
+  - highlighted paper labels
+  - rotated paper cards
+  - handwritten annotation cues
+- Does this branch need additional shared typography treatment to express the handwritten/diary feel, or should that stay unchanged until page-level redesign work proves a concrete need?
+- Is a shared page-header treatment stable enough to belong in this branch, or should that remain page-local until Phase 3 confirms cross-page reuse?
+
+## Research Decision
+
+- Required: yes
+- Why:
+  - `docs/MASTER-PLAN.md` explicitly expects a baseline audit before planning implementation for this branch
+  - the branch must separate reusable shared surfaces from page-local compositions based on current code and current visual patterns, not assumption
+  - token additions should be driven by a real audit of shared design needs rather than speculative styling ideas
+- If yes, research questions:
+  - Which current landing/dashboard visual elements should be kept, refined, or removed?
+  - Which note/paper/tape motifs have enough cross-page reuse value to belong in `src/shared/ui/common`?
+  - Which current elements are too page-specific, too ornamental, or too inconsistent to extract into shared foundations?
+  - What is the minimum additional token set, if any, that is justified for a shared paper/note design system on top of the existing palette?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md (for Mandalart Web)
 
-_Last updated: 2026-03-15 (KST)_
+_Last updated: 2026-03-19 (KST)_
 
 ---
 
@@ -70,6 +70,7 @@ Korean documents under `docs/ko/*.md` must be synchronized after the English sou
 - Prefer semantic utilities such as `bg-background`, `text-foreground`, `text-muted-foreground`, `bg-primary`, and related token-backed classes.
 - Do not introduce raw Tailwind color utilities or ad-hoc color values in component code when an approved token already exists.
 - If a new color/token is truly required, add it to the shared theme token system in `src/app/globals.css` rather than defining a one-off local workaround.
+- When the existing brand palette is directionally correct but insufficient for UI material roles, prefer adding a small number of semantic support roles for reusable surfaces such as paper, tape, line, or shadow behavior instead of inventing new brand hues casually.
 
 ### Data Access Rule
 
@@ -152,6 +153,11 @@ Use this workflow for non-trivial branch work:
 ### Notes For UI Branches
 
 - Branches that explicitly create or redesign user-facing UI should use the design-oriented path during Execution and include UI-guideline review during Review.
+- For design-led UI branches such as visual-system work, design-foundation work, landing/dashboard refreshes, or other user-facing art-direction changes:
+  - prefer `frontend-design` as the primary branch lens
+  - keep `frontend-architecture-rules` as a mandatory structural guardrail for shared/local boundaries, file placement, and token discipline
+  - treat `web-design-guidelines` as a required Review-stage lens, not an optional add-on
+  - if `frontend-design` is not the primary lens for a clearly design-led UI branch, record the reason in branch-local `research.md` or `plan.md`
 
 ### E2E Closeout Communication
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,11 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-note-surface: var(--note-surface);
+  --color-note-surface-raised: var(--note-surface-raised);
+  --color-note-stroke: var(--note-stroke);
+  --color-note-tape: var(--note-tape);
+  --color-note-grid: var(--note-grid);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -59,14 +64,12 @@
 :root {
   --background: var(--color-brand-bg);
   --foreground: var(--color-brand-fg);
-  /* --card: var(--color-brand-bg); */
   --card: var(--color-brand-bg-lighter);
   --card-foreground: var(--color-brand-fg);
   --popover: var(--color-brand-bg);
   --popover-foreground: var(--color-brand-fg);
   --primary: var(--color-brand-primary);
   --primary-foreground: var(--color-brand-bg);
-  /* --secondary: oklch(0.91 0.013 82.4); */
   --secondary: var(--color-brand-secondary);
   --secondary-foreground: var(--color-brand-fg);
   --muted: oklch(0.91 0.013 82.4);
@@ -91,6 +94,18 @@
   --sidebar-accent-foreground: var(--color-brand-bg);
   --sidebar-border: oklch(0.85 0.01 82.4);
   --sidebar-ring: var(--color-brand-secondary);
+
+  /* Semantic support roles for note-like materials. */
+  --note-surface: var(--card);
+  --note-surface-raised: var(--background);
+  --note-stroke: var(--border);
+  --note-tape: color-mix(
+    in oklab,
+    var(--color-brand-primary) 16%,
+    var(--color-brand-bg-lighter) 84%
+  );
+  --note-grid: color-mix(in oklab, var(--color-brand-primary) 12%, transparent);
+  --note-shadow-color: color-mix(in oklab, var(--color-brand-fg) 14%, transparent);
 }
 
 .dark {
@@ -102,7 +117,6 @@
   --popover-foreground: var(--color-brand-bg);
   --primary: var(--color-brand-secondary);
   --primary-foreground: var(--color-brand-bg);
-  /* --secondary: oklch(0.38 0 0); */
   --secondary: var(--color-brand-primary);
   --secondary-foreground: var(--color-brand-bg);
   --muted: oklch(0.38 0 0);
@@ -126,6 +140,17 @@
   --sidebar-accent-foreground: var(--color-brand-bg);
   --sidebar-border: oklch(0.42 0 0);
   --sidebar-ring: var(--color-brand-secondary);
+
+  --note-surface: var(--card);
+  --note-surface-raised: color-mix(
+    in oklab,
+    var(--color-brand-fg-lighter) 86%,
+    var(--color-brand-bg) 14%
+  );
+  --note-stroke: var(--border);
+  --note-tape: color-mix(in oklab, var(--color-brand-bg) 14%, var(--color-brand-fg-lighter) 86%);
+  --note-grid: color-mix(in oklab, var(--color-brand-bg) 16%, transparent);
+  --note-shadow-color: color-mix(in oklab, var(--color-brand-bg) 16%, transparent);
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,7 +104,7 @@
     var(--color-brand-primary) 16%,
     var(--color-brand-bg-lighter) 84%
   );
-  --note-grid: color-mix(in oklab, var(--color-brand-primary) 12%, transparent);
+  --note-grid: var(--color-brand-primary);
   --note-shadow-color: color-mix(in oklab, var(--color-brand-fg) 14%, transparent);
 }
 
@@ -149,7 +149,7 @@
   );
   --note-stroke: var(--border);
   --note-tape: color-mix(in oklab, var(--color-brand-bg) 14%, var(--color-brand-fg-lighter) 86%);
-  --note-grid: color-mix(in oklab, var(--color-brand-bg) 16%, transparent);
+  --note-grid: var(--color-brand-bg);
   --note-shadow-color: color-mix(in oklab, var(--color-brand-bg) 16%, transparent);
 }
 

--- a/src/shared/ui/common/DecoTape.tsx
+++ b/src/shared/ui/common/DecoTape.tsx
@@ -2,8 +2,31 @@ import { cn } from "@/shared/lib/utils";
 
 interface DecoTapeProps {
   className?: string;
+  size?: "sm" | "md" | "lg";
+  tone?: "default" | "quiet";
 }
 
-export function DecoTape({ className }: DecoTapeProps) {
-  return <div className={cn("h-8 w-32 bg-primary/20 opacity-60 backdrop-blur-[1px]", className)} />;
+const SIZE_CLASS = {
+  sm: "h-6 w-20",
+  md: "h-8 w-32",
+  lg: "h-10 w-40",
+} as const;
+
+const TONE_CLASS = {
+  default: "opacity-85",
+  quiet: "opacity-65",
+} as const;
+
+export function DecoTape({ className, size = "md", tone = "default" }: DecoTapeProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "rounded-[2px] border border-note-stroke bg-note-tape shadow-[0_1px_0_0_var(--note-shadow-color)] backdrop-blur-[1.5px]",
+        SIZE_CLASS[size],
+        TONE_CLASS[tone],
+        className,
+      )}
+    />
+  );
 }

--- a/src/shared/ui/common/GridPatternBackground.tsx
+++ b/src/shared/ui/common/GridPatternBackground.tsx
@@ -1,8 +1,36 @@
-export function GridPatternBackground() {
+import { cn } from "@/shared/lib/utils";
+
+interface GridPatternBackgroundProps {
+  className?: string;
+  density?: "tight" | "normal" | "loose";
+  tone?: "subtle" | "default";
+}
+
+const DENSITY_CLASS = {
+  tight: "bg-size-[18px_18px]",
+  normal: "bg-size-[24px_24px]",
+  loose: "bg-size-[32px_32px]",
+} as const;
+
+const TONE_CLASS = {
+  subtle: "opacity-[0.03]",
+  default: "opacity-[0.05]",
+} as const;
+
+export function GridPatternBackground({
+  className,
+  density = "normal",
+  tone = "subtle",
+}: GridPatternBackgroundProps) {
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 bg-[linear-gradient(var(--color-primary)_1px,transparent_1px),linear-gradient(90deg,var(--color-primary)_1px,transparent_1px)] bg-size-[24px_24px] opacity-[0.03]"
+      className={cn(
+        "pointer-events-none absolute inset-0 bg-[linear-gradient(var(--note-grid)_1px,transparent_1px),linear-gradient(90deg,var(--note-grid)_1px,transparent_1px)]",
+        DENSITY_CLASS[density],
+        TONE_CLASS[tone],
+        className,
+      )}
     />
   );
 }

--- a/src/shared/ui/common/NoteSurface.tsx
+++ b/src/shared/ui/common/NoteSurface.tsx
@@ -1,0 +1,42 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/shared/lib/utils";
+import { Card } from "@/shared/ui/shadcn/Card";
+
+const noteSurfaceVariants = cva(
+  "relative overflow-visible border-2 border-note-stroke transition-[background-color,border-color,box-shadow]",
+  {
+    variants: {
+      tone: {
+        surface: "bg-note-surface",
+        raised: "bg-note-surface-raised",
+      },
+      depth: {
+        sm: "shadow-[2px_2px_0_0_var(--note-shadow-color)]",
+        md: "shadow-[4px_4px_0_0_var(--note-shadow-color)]",
+        lg: "shadow-[8px_8px_0_0_var(--note-shadow-color)]",
+      },
+    },
+    defaultVariants: {
+      tone: "surface",
+      depth: "md",
+    },
+  },
+);
+
+interface NoteSurfaceProps
+  extends React.ComponentProps<typeof Card>,
+    VariantProps<typeof noteSurfaceVariants> {}
+
+export function NoteSurface({ className, tone, depth, ...props }: NoteSurfaceProps) {
+  return (
+    <Card
+      data-depth={depth ?? "md"}
+      data-slot="note-surface"
+      data-tone={tone ?? "surface"}
+      className={cn(noteSurfaceVariants({ tone, depth }), className)}
+      {...props}
+    />
+  );
+}

--- a/src/widgets/dashboard-charts/DashboardCharts.tsx
+++ b/src/widgets/dashboard-charts/DashboardCharts.tsx
@@ -2,7 +2,8 @@
 
 import { Area, AreaChart, CartesianGrid, Pie, PieChart, XAxis } from "recharts";
 import { DecoTape } from "@/shared/ui/common/DecoTape";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/shared/ui/shadcn/Card";
+import { NoteSurface } from "@/shared/ui/common/NoteSurface";
+import { CardContent, CardDescription, CardHeader, CardTitle } from "@/shared/ui/shadcn/Card";
 import {
   type ChartConfig,
   ChartContainer,
@@ -34,9 +35,9 @@ export function DashboardCharts() {
       </h2>
 
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-        <div className="group relative transition-transform duration-300 hover:-translate-y-2 hover:-rotate-1">
-          <DecoTape className="absolute -top-3 left-1/2 z-10 origin-right -translate-x-1/2 transition-all duration-500 group-hover:rotate-[-8deg] group-hover:scale-x-0 group-hover:opacity-0" />
-          <Card className="border-2 border-primary/10 shadow-[4px_4px_0px_0px_rgba(45,45,45,0.1)]">
+        <div className="group relative transition-transform duration-300 hover:-translate-y-1">
+          <DecoTape tone="quiet" className="absolute -top-3 left-1/2 z-10 -translate-x-1/2" />
+          <NoteSurface depth="md" className="h-full">
             <CardHeader>
               <CardTitle>Goal Progress</CardTitle>
             </CardHeader>
@@ -62,12 +63,12 @@ export function DashboardCharts() {
                 </AreaChart>
               </ChartContainer>
             </CardContent>
-          </Card>
+          </NoteSurface>
         </div>
 
-        <div className="group relative transition-transform duration-300 hover:-translate-y-2 hover:rotate-1">
-          <DecoTape className="absolute -top-3 left-1/2 z-10 origin-right -translate-x-1/2 transition-all duration-500 group-hover:rotate-[-8deg] group-hover:scale-x-0 group-hover:opacity-0" />
-          <Card className="border-2 border-primary/10 shadow-[4px_4px_0px_0px_rgba(45,45,45,0.1)]">
+        <div className="group relative transition-transform duration-300 hover:-translate-y-1">
+          <DecoTape tone="quiet" className="absolute -top-3 left-1/2 z-10 -translate-x-1/2" />
+          <NoteSurface depth="md" className="h-full">
             <CardHeader className="flex justify-between">
               <CardTitle>Status Distribution</CardTitle>
               <CardDescription>2025 Goals</CardDescription>
@@ -90,7 +91,7 @@ export function DashboardCharts() {
                 </PieChart>
               </ChartContainer>
             </CardContent>
-          </Card>
+          </NoteSurface>
         </div>
       </div>
     </section>

--- a/src/widgets/dashboard-summary/DashboardSummary.tsx
+++ b/src/widgets/dashboard-summary/DashboardSummary.tsx
@@ -6,7 +6,8 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon as Icon } from "@hugeicons/react";
 import { DecoTape } from "@/shared/ui/common/DecoTape";
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/shadcn/Card";
+import { NoteSurface } from "@/shared/ui/common/NoteSurface";
+import { CardContent, CardHeader, CardTitle } from "@/shared/ui/shadcn/Card";
 import { getSummaryStats } from "./model";
 
 export const DashboardSummary = () => {
@@ -41,13 +42,17 @@ export const DashboardSummary = () => {
 
   return (
     <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-      {stats.map((stat, index) => (
+      {stats.map((stat) => (
         <div
           key={stat.title}
-          className={`group relative transition-transform duration-300 ${index % 2 === 0 ? "hover:-rotate-1" : "hover:rotate-1"} hover:-translate-y-2`}
+          className="group relative transition-transform duration-300 hover:-translate-y-1"
         >
-          <DecoTape className="absolute -top-3 left-1/2 z-10 origin-right -translate-x-1/2 transition-all duration-500 group-hover:rotate-[-8deg] group-hover:scale-x-0 group-hover:opacity-0" />
-          <Card className="border-2 border-primary/10 bg-card shadow-[4px_4px_0px_0px_rgba(45,45,45,0.1)]">
+          <DecoTape
+            size="sm"
+            tone="quiet"
+            className="absolute -top-3 left-1/2 z-10 -translate-x-1/2"
+          />
+          <NoteSurface depth="md" className="h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="font-medium text-sm">{stat.title}</CardTitle>
               <Icon icon={stat.icon} className="h-4 w-4 text-muted-foreground" />
@@ -56,7 +61,7 @@ export const DashboardSummary = () => {
               <div className="font-bold text-2xl">{stat.value}</div>
               <p className="text-muted-foreground text-xs">{stat.change}</p>
             </CardContent>
-          </Card>
+          </NoteSurface>
         </div>
       ))}
     </div>

--- a/src/widgets/landing/CtaSection.tsx
+++ b/src/widgets/landing/CtaSection.tsx
@@ -2,6 +2,7 @@ import { ArrowRight01Icon, Mail01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon as Icon } from "@hugeicons/react";
 import { DecoTape } from "@/shared/ui/common/DecoTape";
 import { GridPatternBackground } from "@/shared/ui/common/GridPatternBackground";
+import { NoteSurface } from "@/shared/ui/common/NoteSurface";
 import { Button } from "@/shared/ui/shadcn/Button";
 
 export function CtaSection() {
@@ -10,8 +11,8 @@ export function CtaSection() {
       <GridPatternBackground />
 
       <div className="relative mx-auto max-w-4xl">
-        <div className="rotate-1 border-2 border-primary/10 bg-background p-8 text-center shadow-[8px_8px_0px_0px_rgba(45,45,45,0.1)] sm:p-12">
-          <DecoTape className="absolute -top-4 left-1/2 -translate-x-1/2" />
+        <NoteSurface tone="raised" depth="lg" className="rotate-1 p-8 text-center sm:p-12">
+          <DecoTape size="lg" className="absolute -top-4 left-1/2 -translate-x-1/2" />
 
           <h2 className="mb-6 font-bold text-3xl text-foreground tracking-tight sm:text-4xl">
             Ready to map out your goals?
@@ -24,7 +25,7 @@ export function CtaSection() {
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button
               size="lg"
-              className="h-14 border-2 border-primary bg-primary px-8 text-lg text-primary-foreground shadow-[4px_4px_0px_0px_rgba(45,45,45,0.2)] transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:bg-primary hover:text-primary-foreground hover:shadow-[2px_2px_0px_0px_rgba(45,45,45,0.2)]"
+              className="h-14 border-2 border-primary bg-primary px-8 text-lg text-primary-foreground shadow-[4px_4px_0_0_var(--note-shadow-color)] transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:bg-primary hover:text-primary-foreground hover:shadow-[2px_2px_0_0_var(--note-shadow-color)]"
             >
               Start Planning Free
               <Icon icon={ArrowRight01Icon} className="ml-2 size-5" />
@@ -35,7 +36,7 @@ export function CtaSection() {
             <Icon icon={Mail01Icon} className="size-4" />
             <span>Join 1,000+ others getting organized</span>
           </div>
-        </div>
+        </NoteSurface>
       </div>
     </section>
   );

--- a/src/widgets/landing/CtaSection.tsx
+++ b/src/widgets/landing/CtaSection.tsx
@@ -25,7 +25,7 @@ export function CtaSection() {
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button
               size="lg"
-              className="h-14 border-2 border-primary bg-primary px-8 text-lg text-primary-foreground shadow-[4px_4px_0_0_var(--note-shadow-color)] transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:bg-primary hover:text-primary-foreground hover:shadow-[2px_2px_0_0_var(--note-shadow-color)]"
+              className="h-14 border-2 border-primary bg-primary px-8 text-lg text-primary-foreground shadow-[4px_4px_0_0_var(--note-shadow-color)] transition-[transform,background-color,color,box-shadow] hover:translate-x-[2px] hover:translate-y-[2px] hover:bg-primary hover:text-primary-foreground hover:shadow-[2px_2px_0_0_var(--note-shadow-color)]"
             >
               Start Planning Free
               <Icon icon={ArrowRight01Icon} className="ml-2 size-5" />

--- a/src/widgets/landing/MethodSection.tsx
+++ b/src/widgets/landing/MethodSection.tsx
@@ -5,8 +5,10 @@ import {
   Target02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon as Icon } from "@hugeicons/react";
+import { cn } from "@/shared/lib/utils";
 import { DecoTape } from "@/shared/ui/common/DecoTape";
 import { GridPatternBackground } from "@/shared/ui/common/GridPatternBackground";
+import { NoteSurface } from "@/shared/ui/common/NoteSurface";
 
 const STEPS = [
   {
@@ -56,12 +58,21 @@ export function MethodSection() {
                 </div>
               )}
 
-              <div
-                className={`relative h-full border-2 border-primary/10 bg-background p-6 transition-transform duration-300 group-hover:z-10 group-hover:-translate-y-2 ${step.rotate} shadow-[4px_4px_0px_0px_rgba(45,45,45,0.1)]`}
+              <NoteSurface
+                tone="raised"
+                depth="md"
+                className={cn(
+                  "h-full p-6 transition-transform duration-300 group-hover:-translate-y-2",
+                  step.rotate,
+                )}
               >
-                <DecoTape className="absolute -top-3 left-1/2 -translate-x-1/2 rotate-1" />
+                <DecoTape
+                  size="sm"
+                  tone="quiet"
+                  className="absolute -top-3 left-1/2 -translate-x-1/2 rotate-1"
+                />
 
-                <div className="mb-4 inline-flex size-12 items-center justify-center border-2 border-primary/20 bg-card shadow-[2px_2px_0px_0px_rgba(45,45,45,0.1)]">
+                <div className="mb-4 inline-flex size-12 items-center justify-center border-2 border-note-stroke bg-note-surface shadow-[2px_2px_0_0_var(--note-shadow-color)]">
                   <Icon icon={step.icon} className="size-6 text-primary" />
                 </div>
 
@@ -71,7 +82,7 @@ export function MethodSection() {
                 <div className="absolute -right-2 -bottom-2 font-bold font-handwriting text-4xl text-primary/5">
                   {index + 1}
                 </div>
-              </div>
+              </NoteSurface>
             </div>
           ))}
         </div>

--- a/src/widgets/landing/MethodSection.tsx
+++ b/src/widgets/landing/MethodSection.tsx
@@ -53,7 +53,7 @@ export function MethodSection() {
           {STEPS.map((step, index) => (
             <div key={step.title} className="group relative">
               {index < STEPS.length - 1 && (
-                <div className="absolute top-1/2 -right-4 z-10 hidden -translate-y-1/2 transition-all duration-300 group-hover:z-100 group-hover:translate-x-5 md:block">
+                <div className="absolute top-1/2 -right-4 z-10 hidden -translate-y-1/2 transition-transform duration-300 group-hover:z-100 group-hover:translate-x-5 md:block">
                   <Icon icon={ArrowRight01Icon} className="size-8 text-primary/40" />
                 </div>
               )}


### PR DESCRIPTION
## Linked Issue

Closes #17

## Content

This PR implements the Phase 2 design-foundation work for the UI refresh branch.

It keeps the existing Zieglers visual identity intact, but extracts the lowest-risk shared material system needed before page-level redesign work starts. The goal was not to redesign landing/dashboard in this branch, but to define and validate the shared note/paper/tape foundation that later page refresh branches can build on.

Changed in this PR:

- Added semantic support roles in `src/app/globals.css` for reusable note materials:
  - note surface
  - raised note surface
  - note stroke
  - tape fill
  - note grid
  - note shadow color
- Refined shared low-level helpers in `src/shared/ui/common`:
  - `DecoTape`
  - `GridPatternBackground`
- Added a new shared `NoteSurface` primitive in `src/shared/ui/common/NoteSurface.tsx`
- Applied the shared note foundation to representative landing sections:
  - `MethodSection`
  - `CtaSection`
- Applied the same foundation to representative dashboard surfaces:
  - `DashboardSummary`
  - `DashboardCharts`
- Kept page-level composition, storytelling, and concept-sensitive decisions local
- Tightened project workflow guidance so future design-led UI branches explicitly use:
  - `frontend-design` as the primary lens
  - `frontend-architecture-rules` as the structural guardrail
  - `web-design-guidelines` during Review

Why this approach:

- It preserves the current warm pastel, paper-note identity instead of replacing it.
- It avoids prematurely freezing landing/dashboard redesign decisions before the Phase 3 concept-study branch.
- It gives the next landing branch a stable shared material system while still leaving room for concept exploration and 3-variant comparison.

## Images

Local visual spot-checks were completed for:

- landing `MethodSection`
- landing `CtaSection`
- dashboard summary cards
- dashboard charts section

Please attach current screenshots in the PR if needed.

## Misc

Notes / trade-offs:

- This branch intentionally does **not** introduce page-level shared components such as hero patterns, section header systems, or dashboard-specific layouts.
- Brand hues were not expanded. Instead, the branch adds semantic support roles derived from the existing palette.
- Landing keeps slightly more playful page-local accents; dashboard uses the same material system in a more restrained way.
- No new automated tests were added because this branch focuses on shared visual foundation work rather than data or interaction logic.

Verification performed:

- `pnpm exec biome check src/app/globals.css src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
- `pnpm exec eslint src/shared/ui/common/DecoTape.tsx src/shared/ui/common/GridPatternBackground.tsx src/shared/ui/common/NoteSurface.tsx src/widgets/landing/MethodSection.tsx src/widgets/landing/CtaSection.tsx src/widgets/dashboard-summary/DashboardSummary.tsx src/widgets/dashboard-charts/DashboardCharts.tsx`
- `git diff --check -- ...`
- Manual Playwright visual review on:
  - landing `/`
  - dashboard `/dashboard`
  - desktop and mobile-width spot checks

E2E expectation for closeout: `recommended`
- `pnpm run test:e2e` was not run in this thread.

## Checklist

- [x] Linked issue is correct
- [x] Changes match the issue goal and tasks
- [x] Tests added or updated (if applicable)
- [x] No unintended changes included
